### PR TITLE
feat: 프롬프트 저장 기능 구현

### DIFF
--- a/be/src/main/java/com/interviewmate/be/infrastructure/persistence/question/PromptRepository.java
+++ b/be/src/main/java/com/interviewmate/be/infrastructure/persistence/question/PromptRepository.java
@@ -1,0 +1,14 @@
+package com.interviewmate.be.infrastructure.persistence.question;
+
+import com.interviewmate.be.question.domain.Prompt;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * packageName    : com.interviewmate.be.infrastructure.persistence.question
+ * fileName       : PromptRepository
+ * author         : eumsoli
+ * date           : 2025-03-24
+ * description    : 사용자가 입력한 프롬프트 정보를 관리하는 JPA 리포지토리
+ */
+public interface PromptRepository extends JpaRepository<Prompt, Long> {
+}

--- a/be/src/main/java/com/interviewmate/be/question/application/PromptService.java
+++ b/be/src/main/java/com/interviewmate/be/question/application/PromptService.java
@@ -1,0 +1,57 @@
+package com.interviewmate.be.question.application;
+
+import com.interviewmate.be.infrastructure.persistence.question.PromptRepository;
+import com.interviewmate.be.question.domain.Prompt;
+import com.interviewmate.be.question.dto.PromptRequest;
+import com.interviewmate.be.question.dto.PromptResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * packageName    : com.interviewmate.be.question.application
+ * fileName       : PromptService
+ * author         : eumsoli
+ * date           : 2025-03-24
+ * description    : 프롬프트 저장 비즈니스 로직을 담당하는 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class PromptService {
+
+    private final PromptRepository promptRepository;
+
+    /**
+     * methodName : savePrompt
+     * description : 프롬프트를 저장하고 임시 제목을 생성한다.
+     *
+     * @param promptRequest Prompt 저장 요청 DTO
+     * @return Prompt 저장 응답 DTO
+     */
+    @Transactional
+    public PromptResponse savePrompt(PromptRequest promptRequest) {
+        // TODO Gemini API 연동 후 생성된 요약 제목으로 대체
+        String tempTitle = summarizeTitle(promptRequest.prompt());
+
+        Prompt prompt = Prompt.builder()
+                .title(tempTitle)
+                .prompt(promptRequest.prompt())
+                .build();
+
+        Prompt saved = promptRepository.save(prompt);
+
+        return new PromptResponse(saved.getId(), saved.getTitle(), saved.getPrompt(), saved.getCreatedAt());
+    }
+
+    /**
+     * methodName : summarizeTitle
+     * description : 임시 제목 생성 (앞 20자 잘라내기)
+     *
+     * @param prompt 프롬프트 내용
+     * @return 요약된 제목
+     */
+    private String summarizeTitle(String prompt) {
+        return prompt.length() > 20 ? prompt.substring(0, 20) + "..." : prompt;
+    }
+
+}

--- a/be/src/main/java/com/interviewmate/be/question/domain/Prompt.java
+++ b/be/src/main/java/com/interviewmate/be/question/domain/Prompt.java
@@ -1,0 +1,57 @@
+package com.interviewmate.be.question.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+/**
+ * packageName    : com.interviewmate.be.question.domain
+ * fileName       : Prompt
+ * author         : eumsoli
+ * date           : 2025-03-24
+ * description    : 사용자가 입력한 프롬프트 엔티티 클래스
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Prompt {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Lob
+    @Column(nullable = false)
+    private String prompt;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt; // 등록일
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt; // 수정일
+
+    /**
+     * methodName : Prompt
+     * description : Prompt 생성자 (Builder 패턴 적용)
+     *
+     * @param title   요약 제목
+     * @param prompt  프롬프트 내용
+     */
+    @Builder
+    public Prompt(String title, String prompt) {
+        this.title = title;
+        this.prompt = prompt;
+    }
+
+}

--- a/be/src/main/java/com/interviewmate/be/question/dto/PromptRequest.java
+++ b/be/src/main/java/com/interviewmate/be/question/dto/PromptRequest.java
@@ -1,0 +1,14 @@
+package com.interviewmate.be.question.dto;
+
+/**
+ * packageName    : com.interviewmate.be.question.dto
+ * fileName       : PromptRequest
+ * author         : eumsoli
+ * date           : 2025-03-24
+ * description    : 프롬프트 저장 요청 DTO
+ */
+public record PromptRequest(
+
+        String prompt // 사용자 입력 프롬프트
+
+) {}

--- a/be/src/main/java/com/interviewmate/be/question/dto/PromptResponse.java
+++ b/be/src/main/java/com/interviewmate/be/question/dto/PromptResponse.java
@@ -1,0 +1,19 @@
+package com.interviewmate.be.question.dto;
+
+import java.time.LocalDateTime;
+
+/**
+ * packageName    : com.interviewmate.be.question.dto
+ * fileName       : PromptResponse
+ * author         : eumsoli
+ * date           : 2025-03-24
+ * description    : 프롬프트 저장 응답 DTO
+ */
+public record PromptResponse(
+
+        Long id,
+        String title,
+        String prompt,
+        LocalDateTime createdAt
+
+) {}

--- a/be/src/main/java/com/interviewmate/be/question/presentation/PromptController.java
+++ b/be/src/main/java/com/interviewmate/be/question/presentation/PromptController.java
@@ -1,0 +1,42 @@
+package com.interviewmate.be.question.presentation;
+
+import com.interviewmate.be.question.application.PromptService;
+import com.interviewmate.be.question.dto.PromptRequest;
+import com.interviewmate.be.question.dto.PromptResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * packageName    : com.interviewmate.be.question.presentation
+ * fileName       : PromptController
+ * author         : eumsoli
+ * date           : 2025-03-24
+ * description    : 프롬프트 관련 API를 제공하는 컨트롤러
+ */
+@RestController
+@RequestMapping("/api/prompts")
+@RequiredArgsConstructor
+public class PromptController {
+
+    private final PromptService promptService;
+
+    /**
+     * methodName : savePrompt
+     * description : 프롬프트 저장 API
+     *
+     * @param promptRequest Prompt 저장 요청 DTO
+     * @return ResponseEntity<PromptResponse> 저장된 프롬프트 응답
+     */
+    @PostMapping
+    public ResponseEntity<PromptResponse> savePrompt(@RequestBody PromptRequest promptRequest) {
+        PromptResponse promptResponse = promptService.savePrompt(promptRequest);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(promptResponse);
+    }
+
+}


### PR DESCRIPTION
## ✅ 작업 내용
- Prompt 엔티티 설계 및 생성
- PromptRequest, PromptResponse DTO(record) 정의
- PromptService에서 저장 로직 및 임시 제목 생성 로직 작성
- GeminiPromptController를 통한 저장 API 구현 (POST /api/prompts)
- 응답은 201 Created 상태코드와 함께 프롬프트 정보 반환

## 🔧 추후 작업 예정
- Gemini API 연동을 통해 실제 제목 요약 생성 기능 구현 예정 (feature/question-generate 브랜치)

Closes #6