### PR TITLE
feat: 질문 5개 생성 기능 구현

### DIFF
--- a/be/src/main/java/com/interviewmate/be/infrastructure/openai/GeminiClient.java
+++ b/be/src/main/java/com/interviewmate/be/infrastructure/openai/GeminiClient.java
@@ -1,0 +1,34 @@
+package com.interviewmate.be.infrastructure.openai;
+
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * packageName    : com.interviewmate.be.infrastructure.openai
+ * fileName       : GeminiClient
+ * author         : eumsoli
+ * date           : 2025-03-25
+ * description    : Gemini API를 통해 프롬프트 기반 질문을 생성하는 클라이언트
+ */
+@Component
+public class GeminiClient {
+
+    /**
+     * methodName : generateQuestions
+     * description : 프롬프트를 기반으로 질문 5개를 생성 (임시 Mock 구현)
+     *
+     * @param prompt 사용자가 입력한 프롬프트
+     * @return List<String> 생성된 질문 리스트
+     */
+    public List<String> generateQuestions(String prompt) {
+        // TODO: 이후 Gemini API 연동으로 대체 예정
+        List<String> questions = new ArrayList<>();
+        for (int i = 1; i <= 5; i++) {
+            questions.add(i + "번 질문: [" + prompt + "] 에 대한 질문 " + i);
+        }
+        return questions;
+    }
+
+}

--- a/be/src/main/java/com/interviewmate/be/infrastructure/persistence/question/QuestionRepository.java
+++ b/be/src/main/java/com/interviewmate/be/infrastructure/persistence/question/QuestionRepository.java
@@ -1,0 +1,28 @@
+package com.interviewmate.be.infrastructure.persistence.question;
+
+import com.interviewmate.be.question.domain.Prompt;
+import com.interviewmate.be.question.domain.Question;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+/**
+ * packageName    : com.interviewmate.be.infrastructure.persistence.question
+ * fileName       : QuestionRepository
+ * author         : eumsoli
+ * date           : 2025-03-25
+ * description    : 프롬프트에 대한 질문 정보를 관리하는 JPA 리포지토리
+ */
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+
+    /**
+     * methodName : findMaxNumberByPrompt
+     * description : 특정 프롬프트에 대한 질문 중 가장 큰 번호 조회 (isActive = true만)
+     *
+     * @param prompt 대상 프롬프트
+     * @return Integer 가장 큰 질문 번호 (없으면 null)
+     */
+    @Query("SELECT COALESCE(MAX(q.number), 0) FROM Question q WHERE q.prompt = :prompt AND q.isActive = true")
+    Integer findMaxNumberByPrompt(Prompt prompt);
+
+
+}

--- a/be/src/main/java/com/interviewmate/be/question/application/PromptService.java
+++ b/be/src/main/java/com/interviewmate/be/question/application/PromptService.java
@@ -1,5 +1,6 @@
 package com.interviewmate.be.question.application;
 
+import com.interviewmate.be.auth.domain.User;
 import com.interviewmate.be.infrastructure.persistence.question.PromptRepository;
 import com.interviewmate.be.question.domain.Prompt;
 import com.interviewmate.be.question.dto.PromptRequest;
@@ -13,7 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
  * fileName       : PromptService
  * author         : eumsoli
  * date           : 2025-03-24
- * description    : 프롬프트 저장 비즈니스 로직을 담당하는 서비스
+ * description    : 프롬프트 저장 및 관련 로직을 담당하는 서비스
  */
 @Service
 @RequiredArgsConstructor
@@ -23,24 +24,23 @@ public class PromptService {
 
     /**
      * methodName : savePrompt
-     * description : 프롬프트를 저장하고 임시 제목을 생성한다.
+     * description : 프롬프트 저장 및 요약 제목 생성 처리
      *
-     * @param promptRequest Prompt 저장 요청 DTO
-     * @return Prompt 저장 응답 DTO
+     * @param user 사용자
+     * @param promptContent 사용자 입력 프롬프트
+     * @return Prompt 저장된 프롬프트 엔티티
      */
     @Transactional
-    public PromptResponse savePrompt(PromptRequest promptRequest) {
-        // TODO Gemini API 연동 후 생성된 요약 제목으로 대체
-        String tempTitle = summarizeTitle(promptRequest.prompt());
+    public Prompt savePrompt(User user, String promptContent) {
+        String title = summarizeTitle(promptContent);
 
         Prompt prompt = Prompt.builder()
-                .title(tempTitle)
-                .prompt(promptRequest.prompt())
+                .user(user)
+                .title(title)
+                .prompt(promptContent)
                 .build();
 
-        Prompt saved = promptRepository.save(prompt);
-
-        return new PromptResponse(saved.getId(), saved.getTitle(), saved.getPrompt(), saved.getCreatedAt());
+        return promptRepository.save(prompt);
     }
 
     /**

--- a/be/src/main/java/com/interviewmate/be/question/application/QuestionService.java
+++ b/be/src/main/java/com/interviewmate/be/question/application/QuestionService.java
@@ -1,0 +1,96 @@
+package com.interviewmate.be.question.application;
+
+import com.interviewmate.be.auth.domain.User;
+import com.interviewmate.be.infrastructure.openai.GeminiClient;
+import com.interviewmate.be.infrastructure.persistence.question.PromptRepository;
+import com.interviewmate.be.infrastructure.persistence.question.QuestionRepository;
+import com.interviewmate.be.question.domain.Prompt;
+import com.interviewmate.be.question.domain.Question;
+import com.interviewmate.be.question.dto.QuestionGenerateRequest;
+import com.interviewmate.be.question.dto.QuestionResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * packageName    : com.interviewmate.be.question.application
+ * fileName       : QuestionService
+ * author         : eumsoli
+ * date           : 2025-03-25
+ * description    : Gemini 기반 질문 생성을 담당하는 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class QuestionService {
+
+    private final GeminiClient geminiClient;
+    private final PromptService promptService;
+    private final QuestionRepository questionRepository;
+
+    /**
+     * methodName : generateQuestions
+     * description : Gemini API를 통해 질문을 생성하고, 회원 여부에 따라 저장 처리
+     *
+     * @param request 질문 생성 요청 DTO
+     * @param user    로그인 사용자 (null이면 비회원)
+     * @return List<QuestionResponse> 질문 리스트 응답
+     */
+    @Transactional
+    public List<QuestionResponse> generateQuestions(QuestionGenerateRequest request, User user) {
+        // 질문 생성
+        List<String> generated = geminiClient.generateQuestions(request.prompt());
+
+
+        // 비회원일 경우
+        if(user == null) {
+            return toResponse(generated, 1); // 저장 없이 그대로 응답만
+        }
+
+        // 회원일 경우
+        // 1. 프롬프트 저장
+        Prompt prompt = promptService.savePrompt(user, request.prompt());
+
+        // 2. 현재 질문 번호 채번
+        int maxNumber = questionRepository.findMaxNumberByPrompt(prompt);
+        int startNumber = maxNumber + 1;
+
+        // 3. 질문 저장
+        List<Question> saved = new ArrayList<>();
+
+        for(int i = 0; i < generated.size(); i++) {
+            Question question = Question.builder()
+                    .prompt(prompt)
+                    .number(startNumber + i)
+                    .question(generated.get(i))
+                    .build();
+
+            saved.add(questionRepository.save(question));
+        }
+
+        return saved.stream()
+                .map(question -> new QuestionResponse(question.getNumber(), question.getQuestion()))
+                .toList();
+    }
+
+    /**
+     * methodName : toResponse
+     * description : 질문 리스트를 응답 DTO로 변환
+     *
+     * @param questions    생성된 질문 리스트
+     * @param startNumber  시작 번호
+     * @return List<QuestionResponse>
+     */
+    private List<QuestionResponse> toResponse(List<String> questions, int startNumber) {
+        List<QuestionResponse> questionResponses = new ArrayList<>();
+
+        for(int i = 0; i < questions.size(); i++) {
+            questionResponses.add(new QuestionResponse(startNumber + i, questions.get(i)));
+        }
+
+        return questionResponses;
+    }
+
+}

--- a/be/src/main/java/com/interviewmate/be/question/domain/Prompt.java
+++ b/be/src/main/java/com/interviewmate/be/question/domain/Prompt.java
@@ -1,5 +1,6 @@
 package com.interviewmate.be.question.domain;
 
+import com.interviewmate.be.auth.domain.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -24,7 +25,12 @@ public class Prompt {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "prompt_seq")
     private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_seq")
+    private User user; // 사용자와의 연관 관계
 
     @Column(nullable = false)
     private String title;
@@ -35,7 +41,7 @@ public class Prompt {
 
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
-    private LocalDateTime createdAt; // 등록일
+    private LocalDateTime createdAt; // 작성일
 
     @UpdateTimestamp
     @Column(name = "updated_at")
@@ -45,11 +51,13 @@ public class Prompt {
      * methodName : Prompt
      * description : Prompt 생성자 (Builder 패턴 적용)
      *
+     * @param user    연관된 사용자
      * @param title   요약 제목
      * @param prompt  프롬프트 내용
      */
     @Builder
-    public Prompt(String title, String prompt) {
+    public Prompt(User user, String title, String prompt) {
+        this.user = user;
         this.title = title;
         this.prompt = prompt;
     }

--- a/be/src/main/java/com/interviewmate/be/question/domain/Question.java
+++ b/be/src/main/java/com/interviewmate/be/question/domain/Question.java
@@ -1,0 +1,75 @@
+package com.interviewmate.be.question.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+/**
+ * packageName    : com.interviewmate.be.question.domain
+ * fileName       : Question
+ * author         : eumsoli
+ * date           : 2025-03-25
+ * description    : 사용자가 입력한 프롬프트에 대한 질문 엔티티 클래스
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Question {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "question_seq")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "prompt_seq", nullable = false)
+    private Prompt prompt; // 프롬프트와의 연관 관계
+
+    private int number; // 프롬프트 내 질문 번호 (1~5, 혹은 6...)
+
+    @Lob
+    private String question; // 질문
+
+    @Column(name = "is_active")
+    private boolean isActive; // 비활성화 여부
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt; // 생성일
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt; // 수정일
+
+
+    /**
+     * constructor : Question 생성자
+     * description : Question 객체 생성
+     *
+     * @param prompt  연관된 프롬프트
+     * @param number  질문 번호
+     * @param question 질문 내용
+     */
+    @Builder
+    public Question(Prompt prompt, int number, String question) {
+        this.prompt = prompt;
+        this.number = number;
+        this.question = question;
+        this.isActive = true;
+    }
+
+    /**
+     * methodName : deactivate
+     * description : 질문을 비활성화 상태로 변경
+     */
+    public void deactivate() {
+        this.isActive = false;
+    }
+
+}

--- a/be/src/main/java/com/interviewmate/be/question/dto/QuestionGenerateRequest.java
+++ b/be/src/main/java/com/interviewmate/be/question/dto/QuestionGenerateRequest.java
@@ -1,0 +1,14 @@
+package com.interviewmate.be.question.dto;
+
+/**
+ * packageName    : com.interviewmate.be.question.dto
+ * fileName       : QuestionGenerateRequest
+ * author         : eumsoli
+ * date           : 2025-03-25
+ * description    : Gemini 기반 질문 생성 요청 DTO
+ */
+public record QuestionGenerateRequest(
+
+        String prompt // 사용자 입력 프롬프트 (질문 생성 기준)
+
+) {}

--- a/be/src/main/java/com/interviewmate/be/question/dto/QuestionResponse.java
+++ b/be/src/main/java/com/interviewmate/be/question/dto/QuestionResponse.java
@@ -1,0 +1,15 @@
+package com.interviewmate.be.question.dto;
+
+/**
+ * packageName    : com.interviewmate.be.question.dto
+ * fileName       : QuestionResponse
+ * author         : eumsoli
+ * date           : 2025-03-25
+ * description    : Gemini 기반 생성된 질문 응답 DTO
+ */
+public record QuestionResponse(
+
+        int number,      // 프롬프트 내에서의 질문 번호 (1~5, 또는 6 이후)
+        String question  // 질문 내용
+
+) {}

--- a/be/src/main/java/com/interviewmate/be/question/presentation/PromptController.java
+++ b/be/src/main/java/com/interviewmate/be/question/presentation/PromptController.java
@@ -23,20 +23,5 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class PromptController {
 
-    private final PromptService promptService;
-
-    /**
-     * methodName : savePrompt
-     * description : 프롬프트 저장 API
-     *
-     * @param promptRequest Prompt 저장 요청 DTO
-     * @return ResponseEntity<PromptResponse> 저장된 프롬프트 응답
-     */
-    @PostMapping
-    public ResponseEntity<PromptResponse> savePrompt(@RequestBody PromptRequest promptRequest) {
-        PromptResponse promptResponse = promptService.savePrompt(promptRequest);
-
-        return ResponseEntity.status(HttpStatus.CREATED).body(promptResponse);
-    }
 
 }

--- a/be/src/main/java/com/interviewmate/be/question/presentation/QuestionController.java
+++ b/be/src/main/java/com/interviewmate/be/question/presentation/QuestionController.java
@@ -1,0 +1,51 @@
+package com.interviewmate.be.question.presentation;
+
+import com.interviewmate.be.auth.domain.User;
+import com.interviewmate.be.infrastructure.persistence.auth.UserRepository;
+import com.interviewmate.be.question.application.QuestionService;
+import com.interviewmate.be.question.dto.QuestionGenerateRequest;
+import com.interviewmate.be.question.dto.QuestionResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * packageName    : com.interviewmate.be.question.presentation
+ * fileName       : QuestionController
+ * author         : eumsoli
+ * date           : 2025-03-25
+ * description    : 질문 관련 API를 제공하는 컨트롤러
+ */
+@RestController
+@RequestMapping("/api/questions")
+@RequiredArgsConstructor
+public class QuestionController {
+
+    private final QuestionService questionService;
+
+    /**
+     * methodName : generateQuestions
+     * description : 프롬프트를 기반으로 Gemini 질문 생성
+     *               회원은 질문/프롬프트 저장, 비회원은 질문 생성만 수행
+     *
+     * @param request 프롬프트 요청 DTO
+     * @param user    로그인 사용자 (비회원일 경우 null)
+     * @return ResponseEntity<List<QuestionResponse>> 생성된 질문 리스트
+     */
+    @PostMapping("/generate")
+    public ResponseEntity<List<QuestionResponse>> generateQuestions(
+            @RequestBody QuestionGenerateRequest request,
+            @AuthenticationPrincipal User user
+    ) {
+        List<QuestionResponse> responses = questionService.generateQuestions(request, user);
+        return ResponseEntity.status(HttpStatus.CREATED).body(responses);
+    }
+
+}


### PR DESCRIPTION
## ✅ 작업 내용
- GeminiClient(Mock)를 통해 프롬프트 기반 질문 5개 생성 기능 개발
- 회원 여부에 따라 질문 저장 여부 분기 처리
  - 회원일 경우: 프롬프트 및 질문 저장
  - 비회원일 경우: 질문 생성만 수행하고 응답만 반환
- PromptService를 통해 프롬프트 저장 시 사용자 정보 포함
- QuestionService에서 질문 번호 자동 채번 로직 구현
- QuestionController를 통해 질문 생성 API(`/api/questions/generate`) 구현

## 🔧 기술 고려 사항
- 질문 번호는 isActive=true 상태의 질문 중 최대값 기준 +1로 자동 채번
- 프롬프트와 질문은 각각 User, Prompt와 연관관계를 가짐
- Gemini 연동은 현재 Mock으로 구성되어 있으며, 실제 API 연동은 추후 진행 예정

## 🔜 추후 작업 예정
- 질문 개별 삭제 기능 (비활성화 처리)
- 질문 재생성 기능
- 비활성화된 질문 1개월 후 자동 삭제 (스케줄링)
- Gemini API 실제 연동 기능

Closes #8
