### PR TITLE
feat: 질문 관리 기능 구현 (삭제, 재생성, 조회, 자동삭제)

### DIFF
--- a/be/src/main/java/com/interviewmate/be/BeApplication.java
+++ b/be/src/main/java/com/interviewmate/be/BeApplication.java
@@ -3,7 +3,9 @@ package com.interviewmate.be;
 import io.github.cdimascio.dotenv.Dotenv;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class BeApplication {
 

--- a/be/src/main/java/com/interviewmate/be/common/exception/ErrorCode.java
+++ b/be/src/main/java/com/interviewmate/be/common/exception/ErrorCode.java
@@ -43,13 +43,25 @@ public enum ErrorCode {
     OAUTH2_INVALID_SCOPE(BAD_REQUEST, "요청한 권한이 거부되었습니다."),
     OAUTH2_CLIENT_ERROR(BAD_REQUEST, "OAuth2 클라이언트 설정이 잘못되었습니다."),
 
-    // 공통 관련 예외
-    UNKNOWN_ERROR(INTERNAL_SERVER_ERROR, "알 수 없는 로그인 오류가 발생했습니다."),
-    FORBIDDEN_ACCESS(FORBIDDEN, "접근이 거부되었습니다."),
-
     // 사용자 관련 예외
     EMAIL_ALREADY_EXISTS(CONFLICT, "이미 존재하는 이메일입니다."),
-    USER_NOT_FOUND(NOT_FOUND, "사용자를 찾을 수 없습니다.");
+    USER_NOT_FOUND(NOT_FOUND, "사용자를 찾을 수 없습니다."),
+
+    // 프롬프트 관련 예외
+    PROMPT_NOT_FOUND(NOT_FOUND, "프롬프트를 찾을 수 없습니다."),
+
+    // 질문 관련 예외
+    QUESTION_NOT_FOUND(NOT_FOUND, "질문을 찾을 수 없습니다."),
+    QUESTION_ALREADY_DEACTIVATED(BAD_REQUEST, "이미 비활성화된 질문입니다."),
+    QUESTION_NOT_OWNED(FORBIDDEN, "해당 질문을 삭제할 권한이 없습니다."),
+    QUESTION_REGENERATION_NOT_ALLOWED(BAD_REQUEST, "재생성할 수 있는 질문이 없습니다."),
+
+
+    // 공통 관련 예외
+    LOGIN_REQUIRED(UNAUTHORIZED, "로그인이 필요한 기능입니다. 로그인 후 다시 시도해 주세요."),
+    ACCESS_DENIED(FORBIDDEN, "해당 작업을 수행할 권한이 없습니다."),
+    UNKNOWN_ERROR(INTERNAL_SERVER_ERROR, "알 수 없는 로그인 오류가 발생했습니다."),
+    FORBIDDEN_ACCESS(FORBIDDEN, "접근이 거부되었습니다.");
 
     private final HttpStatus httpStatus; // HTTP 상태 코드
     private final String message; // 에러 메시지

--- a/be/src/main/java/com/interviewmate/be/infrastructure/openai/GeminiClient.java
+++ b/be/src/main/java/com/interviewmate/be/infrastructure/openai/GeminiClient.java
@@ -2,7 +2,6 @@ package com.interviewmate.be.infrastructure.openai;
 
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -10,25 +9,27 @@ import java.util.List;
  * fileName       : GeminiClient
  * author         : eumsoli
  * date           : 2025-03-25
- * description    : Gemini API를 통해 프롬프트 기반 질문을 생성하는 클라이언트
+ * description    : Gemini API와 연동하여 질문을 생성하는 클라이언트
  */
 @Component
-public class GeminiClient {
+public interface GeminiClient {
 
     /**
      * methodName : generateQuestions
-     * description : 프롬프트를 기반으로 질문 5개를 생성 (임시 Mock 구현)
+     * description : 프롬프트를 기반으로 질문 5개를 생성
      *
-     * @param prompt 사용자가 입력한 프롬프트
+     * @param prompt 프롬프트 내용
      * @return List<String> 생성된 질문 리스트
      */
-    public List<String> generateQuestions(String prompt) {
-        // TODO: 이후 Gemini API 연동으로 대체 예정
-        List<String> questions = new ArrayList<>();
-        for (int i = 1; i <= 5; i++) {
-            questions.add(i + "번 질문: [" + prompt + "] 에 대한 질문 " + i);
-        }
-        return questions;
-    }
+    List<String> generateQuestions(String prompt);
+
+    /**
+     * methodName : generateSingleQuestion
+     * description : 프롬프트를 기반으로 질문 1개를 생성
+     *
+     * @param prompt 프롬프트 내용
+     * @return String 생성된 질문 1개
+     */
+    String generateSingleQuestion(String prompt);
 
 }

--- a/be/src/main/java/com/interviewmate/be/infrastructure/openai/GeminiClientImpl.java
+++ b/be/src/main/java/com/interviewmate/be/infrastructure/openai/GeminiClientImpl.java
@@ -1,0 +1,53 @@
+package com.interviewmate.be.infrastructure.openai;
+
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Random;
+
+/**
+ * packageName    : com.interviewmate.be.infrastructure.openai
+ * fileName       : GeminiClientImpl
+ * author         : eumsoli
+ * date           : 2025-03-26
+ * description    : Gemini API와 연동하여 질문을 생성하는 클라이언트 구현체 (현재는 Mock)
+ */
+@Component
+public class GeminiClientImpl implements GeminiClient {
+
+    private static final List<String> MOCK_QUESTIONS = List.of(
+            "이 직무에 지원하게 된 계기는 무엇인가요?",
+            "본인의 강점 중 이 직무에 가장 잘 맞는 부분은 무엇인가요?",
+            "최근 경험 중 문제를 해결한 사례를 설명해주세요.",
+            "팀 내 갈등을 어떻게 해결하셨나요?",
+            "단기간에 새로운 기술을 배운 경험이 있다면 말씀해주세요."
+    );
+
+    private final Random random = new Random();
+
+    /**
+     * methodName : generateQuestions
+     * description : 프롬프트 기반 질문 5개 생성 (Mock)
+     *
+     * @param prompt 프롬프트 내용
+     * @return List<String> 생성된 질문 리스트 (5개 고정)
+     */
+    @Override
+    public List<String> generateQuestions(String prompt) {
+        // TODO 실제 연동 시 prompt를 기반으로 Gemini API 호출
+        return MOCK_QUESTIONS;
+    }
+
+    /**
+     * methodName : generateSingleQuestion
+     * description : 프롬프트 기반 질문 1개를 생성 (Mock)
+     *
+     * @param prompt 프롬프트 내용
+     * @return String 생성된 질문 1개
+     */
+    @Override
+    public String generateSingleQuestion(String prompt) {
+        // TODO 실제 연동 시 prompt 기반으로 Gemini API 호출 후 1개만 파싱
+        return MOCK_QUESTIONS.get(random.nextInt(MOCK_QUESTIONS.size()));
+    }
+}

--- a/be/src/main/java/com/interviewmate/be/infrastructure/persistence/question/QuestionRepository.java
+++ b/be/src/main/java/com/interviewmate/be/infrastructure/persistence/question/QuestionRepository.java
@@ -3,7 +3,11 @@ package com.interviewmate.be.infrastructure.persistence.question;
 import com.interviewmate.be.question.domain.Prompt;
 import com.interviewmate.be.question.domain.Question;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 /**
  * packageName    : com.interviewmate.be.infrastructure.persistence.question
@@ -22,7 +26,34 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
      * @return Integer 가장 큰 질문 번호 (없으면 0)
      */
     @Query("SELECT COALESCE(MAX(q.number), 0) FROM Question q WHERE q.prompt = :prompt AND q.isActive = true")
-    Integer findMaxNumberByPrompt(Prompt prompt);
+    int findMaxNumberByPrompt(Prompt prompt);
 
+    /**
+     * methodName : existsByPromptAndIsActiveFalse
+     * description : 해당 프롬프트에 비활성화된 질문이 존재하는지 여부 확인
+     *
+     * @param prompt 대상 프롬프트
+     * @return boolean true일 경우 비활성 질문 존재
+     */
+    boolean existsByPromptAndIsActiveFalse(Prompt prompt);
 
+    /**
+     * methodName : findAllByPromptAndIsActiveTrueOrderByNumber
+     * description : 특정 프롬프트의 활성화된 질문들을 번호 순으로 조회
+     *
+     * @param prompt 대상 프롬프트
+     * @return List<Question>
+     */
+    List<Question> findAllByPromptAndIsActiveTrueOrderByNumber(Prompt prompt);
+
+    /**
+     * methodName : deleteByIsActiveFalseAndUpdatedAtBefore
+     * description : 비활성화 상태이고 지정된 시각보다 오래된 질문을 삭제한다.
+     *
+     * @param updatedAt 삭제 기준 시간
+     * @return int 삭제된 질문 수
+     */
+    @Modifying
+    @Query("DELETE FROM Question q WHERE q.isActive = false AND q.updatedAt < :updatedAt")
+    int deleteByIsActiveFalseAndUpdatedAtBefore(LocalDateTime updatedAt);
 }

--- a/be/src/main/java/com/interviewmate/be/question/application/QuestionScheduler.java
+++ b/be/src/main/java/com/interviewmate/be/question/application/QuestionScheduler.java
@@ -1,0 +1,36 @@
+package com.interviewmate.be.question.application;
+
+import com.interviewmate.be.infrastructure.persistence.question.QuestionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+/**
+ * packageName    : com.interviewmate.be.question.application
+ * fileName       : QuestionScheduler
+ * author         : eumsoli
+ * date           : 2025-03-26
+ * description    : 1개월 지난 비활성 질문 자동 삭제 스케줄러
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class QuestionScheduler {
+
+    private final QuestionRepository questionRepository;
+
+    /**
+     * methodName : deleteOldInactiveQuestions
+     * description : 비활성화된 지 1개월이 지난 질문을 자동으로 삭제한다.
+     */
+    @Scheduled(cron = "0 0 3 * * *") // 매일 새벽 3시
+    public void deleteOldInactiveQuestions() {
+        LocalDateTime expired = LocalDateTime.now().minusMonths(1);
+        int deleted = questionRepository.deleteByIsActiveFalseAndUpdatedAtBefore(expired);
+        log.info("[질문 자동 삭제] 1개월 지난 비활성 질문 {}개 삭제 완료", deleted);
+    }
+
+}

--- a/be/src/main/java/com/interviewmate/be/question/application/QuestionService.java
+++ b/be/src/main/java/com/interviewmate/be/question/application/QuestionService.java
@@ -1,11 +1,16 @@
 package com.interviewmate.be.question.application;
 
 import com.interviewmate.be.auth.domain.User;
+import com.interviewmate.be.common.exception.CustomException;
+import com.interviewmate.be.common.exception.ErrorCode;
 import com.interviewmate.be.infrastructure.openai.GeminiClient;
+import com.interviewmate.be.infrastructure.persistence.question.PromptRepository;
 import com.interviewmate.be.infrastructure.persistence.question.QuestionRepository;
 import com.interviewmate.be.question.domain.Prompt;
 import com.interviewmate.be.question.domain.Question;
 import com.interviewmate.be.question.dto.QuestionGenerateRequest;
+import com.interviewmate.be.question.dto.QuestionListResponse;
+import com.interviewmate.be.question.dto.QuestionRegenerateRequest;
 import com.interviewmate.be.question.dto.QuestionResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -28,6 +33,7 @@ public class QuestionService {
     private final GeminiClient geminiClient;
     private final PromptService promptService;
     private final QuestionRepository questionRepository;
+    private final PromptRepository promptRepository;
 
     /**
      * methodName : generateQuestions
@@ -41,7 +47,6 @@ public class QuestionService {
     public List<QuestionResponse> generateQuestions(QuestionGenerateRequest request, User user) {
         // 질문 생성
         List<String> generated = geminiClient.generateQuestions(request.prompt());
-
 
         // 비회원일 경우
         if(user == null) {
@@ -70,8 +75,98 @@ public class QuestionService {
         }
 
         return saved.stream()
-                .map(question -> new QuestionResponse(question.getNumber(), question.getQuestion()))
+                .map(q -> new QuestionResponse(q.getNumber(), q.getQuestion()))
                 .toList();
+    }
+
+    /**
+     * methodName : deactivateQuestion
+     * description : 질문을 삭제(비활성화) 처리한다.
+     *
+     * @param questionId 질문 ID
+     * @param user       로그인 사용자
+     * @throws CustomException 질문이 없거나 권한이 없거나 이미 비활성화된 경우
+     */
+    @Transactional
+    public void deactivateQuestion(Long questionId, User user) {
+        Question question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new CustomException(ErrorCode.QUESTION_NOT_FOUND));
+
+        // 사용자 자신의 프롬프트인 지 확인
+        if (!question.getPrompt().getUser().getId().equals(user.getId())) {
+            throw new CustomException(ErrorCode.QUESTION_NOT_OWNED);
+        }
+
+        // 이미 비활성화 되었는 지 확인
+        if (!question.isActive()) {
+            throw new CustomException(ErrorCode.QUESTION_ALREADY_DEACTIVATED);
+        }
+
+        question.deactivate();
+    }
+
+    /**
+     * methodName : regenerateQuestion
+     * description : 비활성화된 질문이 존재할 경우, 새 질문을 하나 생성한다.
+     *
+     * @param request 질문 재생성 요청 DTO
+     * @param user    로그인 사용자
+     * @return QuestionResponse 생성된 질문 응답
+     */
+    @Transactional
+    public QuestionResponse regenerateQuestion(QuestionRegenerateRequest request, User user) {
+        Prompt prompt = promptRepository.findById(request.promptId())
+                .orElseThrow(() -> new CustomException(ErrorCode.PROMPT_NOT_FOUND));
+
+        if (!prompt.getUser().getId().equals(user.getId())) {
+            throw new CustomException(ErrorCode.QUESTION_NOT_OWNED);
+        }
+
+        // 비활성화된 질문이 존재하는지 확인
+        boolean hasInactive = questionRepository.existsByPromptAndIsActiveFalse(prompt);
+
+        if (!hasInactive) {
+            throw new CustomException(ErrorCode.QUESTION_REGENERATION_NOT_ALLOWED);
+        }
+
+        // 새로운 질문 생성
+        String newQuestion = geminiClient.generateSingleQuestion(prompt.getPrompt());
+
+        int maxNumber = questionRepository.findMaxNumberByPrompt(prompt);
+        Question question = Question.builder()
+                .prompt(prompt)
+                .question(newQuestion)
+                .number(maxNumber + 1)
+                .build();
+
+        Question saved = questionRepository.save(question);
+        return new QuestionResponse(saved.getNumber(), saved.getQuestion());
+    }
+
+    /**
+     * methodName : getActiveQuestions
+     * description : 특정 프롬프트의 활성 질문들을 조회
+     *
+     * @param promptId 프롬프트 ID
+     * @param user     로그인 사용자
+     * @return QuestionListResponse 질문 목록 응답
+     */
+    @Transactional(readOnly = true)
+    public QuestionListResponse getActiveQuestions(Long promptId, User user) {
+        Prompt prompt = promptRepository.findById(promptId)
+                .orElseThrow(() -> new CustomException(ErrorCode.PROMPT_NOT_FOUND));
+
+        if (!prompt.getUser().getId().equals(user.getId())) {
+            throw new CustomException(ErrorCode.QUESTION_NOT_OWNED);
+        }
+
+        List<Question> questions = questionRepository.findAllByPromptAndIsActiveTrueOrderByNumber(prompt);
+
+        List<QuestionResponse> responseList = questions.stream()
+                .map(q -> new QuestionResponse(q.getNumber(), q.getQuestion()))
+                .toList();
+
+        return new QuestionListResponse(responseList);
     }
 
     /**

--- a/be/src/main/java/com/interviewmate/be/question/dto/QuestionGenerateRequest.java
+++ b/be/src/main/java/com/interviewmate/be/question/dto/QuestionGenerateRequest.java
@@ -5,7 +5,7 @@ package com.interviewmate.be.question.dto;
  * fileName       : QuestionGenerateRequest
  * author         : eumsoli
  * date           : 2025-03-25
- * description    : Gemini 기반 질문 생성 요청 DTO
+ * description    : 질문 생성 요청 DTO
  */
 public record QuestionGenerateRequest(
 

--- a/be/src/main/java/com/interviewmate/be/question/dto/QuestionListResponse.java
+++ b/be/src/main/java/com/interviewmate/be/question/dto/QuestionListResponse.java
@@ -1,0 +1,16 @@
+package com.interviewmate.be.question.dto;
+
+import java.util.List;
+
+/**
+ * packageName    : com.interviewmate.be.question.dto
+ * fileName       : QuestionListResponse
+ * author         : eumsoli
+ * date           : 2025-03-26
+ * description    : 질문 목록 조회 응답 DTO
+ */
+public record QuestionListResponse(
+
+        List<QuestionResponse> questions // 질문 목록
+
+) {}

--- a/be/src/main/java/com/interviewmate/be/question/dto/QuestionRegenerateRequest.java
+++ b/be/src/main/java/com/interviewmate/be/question/dto/QuestionRegenerateRequest.java
@@ -1,0 +1,14 @@
+package com.interviewmate.be.question.dto;
+
+/**
+ * packageName    : com.interviewmate.be.question.dto
+ * fileName       : QuestionRegenerateRequest
+ * author         : eumsoli
+ * date           : 2025-03-26
+ * description    : 질문 재생성 요청 DTO
+ */
+public record QuestionRegenerateRequest(
+
+        Long promptId // 재생성할 프롬프트
+
+) {}

--- a/be/src/main/java/com/interviewmate/be/question/dto/QuestionResponse.java
+++ b/be/src/main/java/com/interviewmate/be/question/dto/QuestionResponse.java
@@ -5,7 +5,7 @@ package com.interviewmate.be.question.dto;
  * fileName       : QuestionResponse
  * author         : eumsoli
  * date           : 2025-03-25
- * description    : Gemini 기반 생성된 질문 응답 DTO
+ * description    : 생성된 질문 응답 DTO
  */
 public record QuestionResponse(
 

--- a/be/src/main/java/com/interviewmate/be/question/presentation/QuestionController.java
+++ b/be/src/main/java/com/interviewmate/be/question/presentation/QuestionController.java
@@ -1,17 +1,18 @@
 package com.interviewmate.be.question.presentation;
 
 import com.interviewmate.be.auth.domain.User;
+import com.interviewmate.be.common.exception.CustomException;
+import com.interviewmate.be.common.exception.ErrorCode;
 import com.interviewmate.be.question.application.QuestionService;
 import com.interviewmate.be.question.dto.QuestionGenerateRequest;
+import com.interviewmate.be.question.dto.QuestionListResponse;
+import com.interviewmate.be.question.dto.QuestionRegenerateRequest;
 import com.interviewmate.be.question.dto.QuestionResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -45,6 +46,70 @@ public class QuestionController {
     ) {
         List<QuestionResponse> responses = questionService.generateQuestions(request, user);
         return ResponseEntity.status(HttpStatus.CREATED).body(responses);
+    }
+
+    /**
+     * methodName : deactivateQuestion
+     * description : 특정 질문을 비활성화(삭제) 처리
+     *
+     * @param questionId 질문 ID (PathVariable)
+     * @param user       로그인 사용자
+     * @return ResponseEntity<Void> 204 No Content 반환
+     * @throws CustomException 질문이 존재하지 않거나 권한이 없는 경우
+     */
+    @DeleteMapping("/{questionId}")
+    public ResponseEntity<Void> deactivateQuestion(
+            @PathVariable Long questionId,
+            @AuthenticationPrincipal User user
+    ) {
+        if (user == null) {
+            throw new CustomException(ErrorCode.LOGIN_REQUIRED);
+        }
+
+        questionService.deactivateQuestion(questionId, user);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * methodName : regenerateQuestion
+     * description : 비활성화된 질문이 존재하면 새 질문을 하나 생성한다.
+     *
+     * @param request 재생성 요청 DTO
+     * @param user    로그인 사용자
+     * @return ResponseEntity<QuestionResponse> 새로 생성된 질문 응답
+     */
+    @PostMapping("/regenerate")
+    public ResponseEntity<QuestionResponse> regenerateQuestion(
+            @RequestBody QuestionRegenerateRequest request,
+            @AuthenticationPrincipal User user
+    ) {
+        if (user == null) {
+            throw new CustomException(ErrorCode.LOGIN_REQUIRED);
+        }
+
+        QuestionResponse response = questionService.regenerateQuestion(request, user);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * methodName : getQuestions
+     * description : 특정 프롬프트의 활성 질문들을 조회
+     *
+     * @param promptId 프롬프트 ID
+     * @param user     로그인 사용자
+     * @return ResponseEntity<QuestionListResponse> 질문 목록 응답
+     */
+    @GetMapping("/prompt/{promptId}")
+    public ResponseEntity<QuestionListResponse> getQuestions(
+            @PathVariable Long promptId,
+            @AuthenticationPrincipal User user
+    ) {
+        if (user == null) {
+            throw new CustomException(ErrorCode.LOGIN_REQUIRED);
+        }
+
+        QuestionListResponse response = questionService.getActiveQuestions(promptId, user);
+        return ResponseEntity.ok(response);
     }
 
 }


### PR DESCRIPTION
## ✅ 작업 내용
- 질문 삭제 기능 구현
  - 로그인 사용자가 자신의 프롬프트에 속한 질문만 삭제 가능
  - 삭제는 DB 삭제가 아닌 isActive = false 로 처리
- 질문 재생성 기능 구현
  - 비활성화된 질문이 존재할 경우, 새로운 질문 하나만 생성
  - 기존 질문 번호 중 가장 큰 번호 기준으로 +1 할당
- 질문 조회 기능 구현
  - 프롬프트 ID 기준으로 활성화된 질문만 조회
  - 번호 순 정렬 후 응답 (1,2,4,5,6 등)
- 질문 자동 삭제 스케줄링
  - 매일 새벽 3시, 1개월 지난 비활성 질문 자동 삭제 처리
- Controller → 인증, Service → 비즈니스 권한 체크로 책임 분리 적용
- GeminiClient에서 프롬프트 기반 질문 1개/5개 생성 메서드 제공 (현재 Mock)

## 🔧 기타 변경 사항
- QuestionScheduler는 application 계층에 배치
- ErrorCode에 QUESTION_XXX 네이밍 추가
- 모든 클래스 및 메서드 주석 작성 완료

## ⏭️ 다음 작업 예정
- Gemini API 실 연동 적용
- 프롬프트 목록 조회 기능
- Swagger 문서화 및 통합 테스트 작성

Closes #11