### PR TITLE
feat: Gemini API 연동

### DIFF
--- a/be/src/main/java/com/interviewmate/be/auth/application/OAuth2UserService.java
+++ b/be/src/main/java/com/interviewmate/be/auth/application/OAuth2UserService.java
@@ -55,13 +55,13 @@ public class OAuth2UserService extends DefaultOAuth2UserService {
         String email = userInfo.getEmail();
         String name = userInfo.getName();
 
-        // 1️⃣ 이메일로 사용자 존재 여부 확인
+        // 이메일로 사용자 존재 여부 확인
         Optional<User> sameEmailUser = userRepository.findByEmail(email);
 
         if (sameEmailUser.isPresent()) {
             User existingUser = sameEmailUser.get();
 
-            // 2️⃣ 이메일은 같지만 소셜 제공자가 다른 경우 예외 처리
+            // 이메일은 같지만 소셜 제공자가 다른 경우 예외 처리
             if (!existingUser.getProvider().equalsIgnoreCase(provider)) {
                 log.warn("소셜 제공자 불일치: 기존={}, 요청={}", existingUser.getProvider(), provider);
 
@@ -74,7 +74,7 @@ public class OAuth2UserService extends DefaultOAuth2UserService {
             return new OAuth2UserPrincipal(provider, oAuth2User); // 기존 사용자
         }
 
-        // 3️⃣ 신규 사용자 가입
+        // 신규 사용자 가입
         User newUser = User.builder()
                 .email(email)
                 .name(name)

--- a/be/src/main/java/com/interviewmate/be/auth/dto/RefreshTokenRequest.java
+++ b/be/src/main/java/com/interviewmate/be/auth/dto/RefreshTokenRequest.java
@@ -15,6 +15,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "Access Token 재발급 요청 DTO")
 public class RefreshTokenRequest {
 
     @Schema(description = "사용자의 Refresh Token", example = "eyJhbGciOiJIUzI1...")

--- a/be/src/main/java/com/interviewmate/be/auth/presentation/AuthController.java
+++ b/be/src/main/java/com/interviewmate/be/auth/presentation/AuthController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -30,29 +31,29 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
+@Tag(name = "Auth", description = "JWT 인증 관련 API")
 public class AuthController {
 
     private final AuthService authService;
 
     /**
-     * methodName : refreshToken
+     * methodName : refreshAccessToken
      * description : Refresh Token을 이용하여 새로운 Access Token 발급 API
      *
      * @param request Refresh Token 요청 DTO
      * @return 새로운 Access Token
      */
-    @PostMapping("/refresh")
     @Operation(
             summary = "Access Token 재발급",
             description = "Refresh Token을 이용하여 새로운 Access Token을 발급합니다.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "Access Token 재발급 성공"),
-                    @ApiResponse(responseCode = "400", description = "Refresh Token이 제공되지 않음"),
                     @ApiResponse(responseCode = "401", description = "유효하지 않은 Refresh Token"),
-                    @ApiResponse(responseCode = "404", description = "Refresh Token이 존재하지 않음")
+                    @ApiResponse(responseCode = "404", description = "Refresh Token을 찾을 수 없음")
             }
     )
-    public ResponseEntity<Map<String, String>> refreshToken(
+    @PostMapping("/refresh")
+    public ResponseEntity<Map<String, String>> refreshAccessToken(
             @RequestBody(description = "Refresh Token 요청 객체") RefreshTokenRequest request) {
         log.info("요청 받은 Refresh Token: {}", request.getRefreshToken());
 
@@ -73,8 +74,6 @@ public class AuthController {
      *
      * @param user 인증된 사용자 정보 (providerId 기반)
      */
-    @PostMapping("/logout")
-    @SecurityRequirement(name = "bearerAuth")
     @Operation(
             summary = "로그아웃",
             description = """
@@ -83,10 +82,11 @@ public class AuthController {
                         """,
             responses = {
                     @ApiResponse(responseCode = "204", description = "로그아웃 성공"),
-                    @ApiResponse(responseCode = "400", description = "Refresh Token이 제공되지 않음"),
-                    @ApiResponse(responseCode = "401", description = "유효하지 않은 Refresh Token")
+                    @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
             }
     )
+    @SecurityRequirement(name = "bearerAuth")
+    @PostMapping("/logout")
     public ResponseEntity<Void> logout(@AuthenticationPrincipal User user) {
         if (user == null) {
             log.warn("로그아웃 요청: 인증된 사용자 없음");

--- a/be/src/main/java/com/interviewmate/be/auth/presentation/UserController.java
+++ b/be/src/main/java/com/interviewmate/be/auth/presentation/UserController.java
@@ -8,6 +8,7 @@ import com.interviewmate.be.common.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -30,6 +31,8 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/user")
 @RequiredArgsConstructor
+@SecurityRequirement(name = "bearerAuth")
+@Tag(name = "User", description = "사용자 관련 API")
 public class UserController {
 
     private final UserService userService;
@@ -43,13 +46,12 @@ public class UserController {
      * @return 사용자 정보 (email, name, providerId, provider)
      */
     @GetMapping("/me")
-    @SecurityRequirement(name = "bearerAuth")
     @Operation(
             summary = "현재 로그인된 사용자 정보 조회",
             description = "JWT Access Token을 기반으로 현재 로그인한 사용자의 정보를 반환합니다.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "사용자 정보 조회 성공"),
-                    @ApiResponse(responseCode = "401", description = "JWT 토큰이 유효하지 않음")
+                    @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
             }
     )
     public ResponseEntity<Map<String, Object>> getCurrentUser(@AuthenticationPrincipal User user) {
@@ -70,13 +72,13 @@ public class UserController {
 
     /**
      * methodName : deleteUser
-     * description : 회원 탈퇴 API - 현재 로그인된 사용자를 DB에서 삭제하고, Refresh Token도 Redis에서 제거
+     * description : 회원 탈퇴 API
+     *               현재 로그인된 사용자를 DB에서 삭제하고, Refresh Token도 Redis에서 제거
      *
      * @param user 현재 로그인된 사용자
      * @return 204 No Content
      */
     @DeleteMapping
-    @SecurityRequirement(name = "bearerAuth")
     @Operation(
             summary = "회원 탈퇴",
             description = """
@@ -85,7 +87,8 @@ public class UserController {
                         """,
             responses = {
                     @ApiResponse(responseCode = "204", description = "회원 탈퇴 및 로그아웃 성공"),
-                    @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+                    @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+                    @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음"),
             }
     )
     public ResponseEntity<Void> deleteUser(@AuthenticationPrincipal User user) {

--- a/be/src/main/java/com/interviewmate/be/common/config/GeminiConfig.java
+++ b/be/src/main/java/com/interviewmate/be/common/config/GeminiConfig.java
@@ -1,0 +1,24 @@
+package com.interviewmate.be.common.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * packageName    : com.interviewmate.be.common.config
+ * fileName       : GeminiConfig
+ * author         : eumsoli
+ * date           : 2025-04-05
+ * description    : Gemini API 설정 클래스
+ */
+@Getter
+@Configuration
+public class GeminiConfig {
+
+    @Value("${gemini.api.key}")
+    private String apiKey;
+
+    @Value("${gemini.api.url}")
+    private String apiUrl;
+
+}

--- a/be/src/main/java/com/interviewmate/be/common/exception/ErrorCode.java
+++ b/be/src/main/java/com/interviewmate/be/common/exception/ErrorCode.java
@@ -35,7 +35,7 @@ public enum ErrorCode {
     UNSUPPORTED_TOKEN(UNAUTHORIZED, "지원되지 않는 JWT 토큰입니다."),
     INVALID_TOKEN(UNAUTHORIZED, "유효하지 않은 JWT 토큰입니다."),
     UNAUTHORIZED_ACCESS(UNAUTHORIZED, "인증되지 않은 접근입니다. 로그인 후 이용해 주세요."),
-    TOKEN_NOT_FOUND(UNAUTHORIZED, "Refresh Token을 찾을 수 없습니다."),
+    TOKEN_NOT_FOUND(NOT_FOUND, "Refresh Token을 찾을 수 없습니다."),
 
     // 인증 실패 관련 예외
     OAUTH2_PROVIDER_MISMATCH(CONFLICT, "해당 이메일은 다른 소셜 계정으로 이미 가입되어 있습니다."),
@@ -58,6 +58,11 @@ public enum ErrorCode {
     QUESTION_ALREADY_DEACTIVATED(BAD_REQUEST, "이미 비활성화된 질문입니다."),
     QUESTION_ACCESS_DENIED(FORBIDDEN, "해당 질문에 대한 권한이 없습니다."),
     QUESTION_REGENERATION_NOT_ALLOWED(BAD_REQUEST, "재생성할 수 있는 질문이 없습니다."),
+
+    // GEMINI 관련 예외
+    GEMINI_API_REQUEST_ERROR(INTERNAL_SERVER_ERROR, "Gemini API 요청 생성 중 오류가 발생했습니다."),
+    GEMINI_API_CALL_FAILED(INTERNAL_SERVER_ERROR, "Gemini API 호출 중 오류가 발생했습니다."),
+    GEMINI_API_RESPONSE_PARSE_ERROR(INTERNAL_SERVER_ERROR, "Gemini API 응답 파싱 중 오류가 발생했습니다."),
 
     // 공통 관련 예외
     LOGIN_REQUIRED(UNAUTHORIZED, "로그인이 필요한 기능입니다. 로그인 후 다시 시도해 주세요."),

--- a/be/src/main/java/com/interviewmate/be/common/security/SecurityConfig.java
+++ b/be/src/main/java/com/interviewmate/be/common/security/SecurityConfig.java
@@ -53,7 +53,9 @@ public class SecurityConfig {
 
                 // 요청별 보안 설정
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/", "/api/auth/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll() // 인증 관련 엔드포인트는 모두 허용
+                        .requestMatchers("/", "/api/auth/**").permitAll() // 인증 관련 엔드포인트는 모두 허용
+                        .requestMatchers("/api/questions/generate").permitAll() // 질문 생성 엔드포인트는 모두 허용
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll() // swagger 관련 엔드포인트는 모두 허용
                         .anyRequest().authenticated() // 나머지는 인증 필요
                 )
 

--- a/be/src/main/java/com/interviewmate/be/infrastructure/openai/GeminiClient.java
+++ b/be/src/main/java/com/interviewmate/be/infrastructure/openai/GeminiClient.java
@@ -1,8 +1,7 @@
 package com.interviewmate.be.infrastructure.openai;
 
+import com.interviewmate.be.infrastructure.openai.dto.GeminiResponse;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 /**
  * packageName    : com.interviewmate.be.infrastructure.openai
@@ -21,7 +20,7 @@ public interface GeminiClient {
      * @param prompt 프롬프트 내용
      * @return List<String> 생성된 질문 리스트
      */
-    List<String> generateQuestions(String prompt);
+    GeminiResponse generateQuestions(String prompt);
 
     /**
      * methodName : generateSingleQuestion

--- a/be/src/main/java/com/interviewmate/be/infrastructure/openai/GeminiClientImpl.java
+++ b/be/src/main/java/com/interviewmate/be/infrastructure/openai/GeminiClientImpl.java
@@ -1,9 +1,22 @@
 package com.interviewmate.be.infrastructure.openai;
 
-import org.springframework.stereotype.Component;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.interviewmate.be.common.config.GeminiConfig;
+import com.interviewmate.be.common.exception.CustomException;
+import com.interviewmate.be.common.exception.ErrorCode;
+import com.interviewmate.be.infrastructure.openai.dto.GeminiResponse;
+import com.interviewmate.be.infrastructure.openai.dto.GeminiResponse.QuestionItem;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 
 /**
  * packageName    : com.interviewmate.be.infrastructure.openai
@@ -12,42 +25,180 @@ import java.util.Random;
  * date           : 2025-03-26
  * description    : Gemini API와 연동하여 질문을 생성하는 클라이언트 구현체 (현재는 Mock)
  */
-@Component
+@Slf4j
+@Service
+@RequiredArgsConstructor
 public class GeminiClientImpl implements GeminiClient {
 
-    private static final List<String> MOCK_QUESTIONS = List.of(
-            "이 직무에 지원하게 된 계기는 무엇인가요?",
-            "본인의 강점 중 이 직무에 가장 잘 맞는 부분은 무엇인가요?",
-            "최근 경험 중 문제를 해결한 사례를 설명해주세요.",
-            "팀 내 갈등을 어떻게 해결하셨나요?",
-            "단기간에 새로운 기술을 배운 경험이 있다면 말씀해주세요."
-    );
+    private final GeminiConfig geminiConfig;
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
-    private final Random random = new Random();
+    // 면접 질문 5개 + 요약 제목 요청용 시스템 프롬프트
+    private static final String MULTI_QUESTION_PROMPT = """
+        다음 프롬프트를 요약한 제목과 관련된 면접 질문 5개를 JSON 형태로 만들어줘.
+        백틱(```) 없이 {"title": "...", "questions": ["질문1", "질문2", ...]} 형태로만 응답해줘.
+        """;
+
+    // 단일 질문 요청용 시스템 프롬프트
+    private static final String SINGLE_QUESTION_PROMPT = """
+        다음 프롬프트를 기반으로 면접 질문 1개를 JSON 형태로 만들어줘.
+        백틱(```) 없이 {"question": "질문1"} 형태로만 응답해줘.
+        """;
 
     /**
      * methodName : generateQuestions
-     * description : 프롬프트 기반 질문 5개 생성 (Mock)
+     * description : Gemini API를 호출하여 제목 및 질문 5개를 생성한다.
      *
-     * @param prompt 프롬프트 내용
-     * @return List<String> 생성된 질문 리스트 (5개 고정)
+     * @param prompt 사용자가 입력한 프롬프트
+     * @return GeminiResponse 생성된 제목 및 질문 리스트
+     * @throws CustomException Gemini API 호출 실패 또는 응답 파싱 실패 시 발생
      */
     @Override
-    public List<String> generateQuestions(String prompt) {
-        // TODO 실제 연동 시 prompt를 기반으로 Gemini API 호출
-        return MOCK_QUESTIONS;
+    public GeminiResponse generateQuestions(String prompt) {
+        try {
+            String requestBody = buildGeminiRequestBody(MULTI_QUESTION_PROMPT, prompt);
+            String responseBody = getGeminiResponseBody(requestBody);
+
+            log.error("[Gemini] 응답 본문: {}", responseBody);
+
+            JsonNode root = objectMapper.readTree(responseBody);
+            String content = root.path("candidates").get(0)
+                                .path("content")
+                                .path("parts").get(0)
+                                .path("text").asText()
+                                // 백틱 제거
+                                .replaceAll("```json", "")
+                                .replaceAll("```", "")
+                                .trim();
+
+            JsonNode jsonNode = objectMapper.readTree(content);
+            String title = jsonNode.path("title").asText();
+            JsonNode questions = jsonNode.path("questions");
+
+            List<QuestionItem> questionList = new ArrayList<>();
+            for (JsonNode q : questions) {
+                questionList.add(new QuestionItem(q.asText()));
+            }
+
+            return new GeminiResponse(title, questionList);
+
+        } catch (JsonProcessingException e) {
+            log.error("[Gemini] 응답 파싱 실패: {}", e.getMessage(), e);
+            throw new CustomException(ErrorCode.GEMINI_API_RESPONSE_PARSE_ERROR);
+        } catch (RestClientException e) {
+            log.error("[Gemini] API 통신 실패: {}", e.getMessage(), e);
+            throw new CustomException(ErrorCode.GEMINI_API_CALL_FAILED);
+        }
+
     }
 
     /**
      * methodName : generateSingleQuestion
-     * description : 프롬프트 기반 질문 1개를 생성 (Mock)
+     * description : Gemini API를 호출하여 질문 1개만 재생성한다.
      *
-     * @param prompt 프롬프트 내용
-     * @return String 생성된 질문 1개
+     * @param prompt 사용자가 입력한 프롬프트
+     * @return String 재생성된 단일 질문
+     * @throws CustomException Gemini API 호출 실패 또는 응답 파싱 실패 시 발생
      */
     @Override
     public String generateSingleQuestion(String prompt) {
-        // TODO 실제 연동 시 prompt 기반으로 Gemini API 호출 후 1개만 파싱
-        return MOCK_QUESTIONS.get(random.nextInt(MOCK_QUESTIONS.size()));
+        try {
+            String requestBody = buildGeminiRequestBody(SINGLE_QUESTION_PROMPT, prompt);
+            String responseBody = getGeminiResponseBody(requestBody);
+
+            log.error("[Gemini] 응답 본문: {}", responseBody);
+
+            JsonNode root = objectMapper.readTree(responseBody);
+            String content = root.path("candidates").get(0)
+                                .path("content")
+                                .path("parts").get(0)
+                                .path("text").asText()
+                                // 백틱 제거
+                                .replaceAll("```json", "")
+                                .replaceAll("```", "")
+                                .trim();
+
+            JsonNode json = objectMapper.readTree(content);
+            return json.path("question").asText();
+
+        } catch (JsonProcessingException e) {
+            log.error("[Gemini] 단일 응답 파싱 실패: {}", e.getMessage(), e);
+            throw new CustomException(ErrorCode.GEMINI_API_RESPONSE_PARSE_ERROR);
+        } catch (RestClientException e) {
+            log.error("[Gemini] 단일 질문 생성 통신 실패: {}", e.getMessage(), e);
+            throw new CustomException(ErrorCode.GEMINI_API_CALL_FAILED);
+        }
+
     }
+
+    /**
+     * methodName : buildGeminiRequestBody
+     * description : Gemini API 요청 바디를 구성하는 헬퍼 메서드
+     *
+     * @param systemPrompt 시스템 메시지 (요청 형식 안내 등)
+     * @param userPrompt 사용자 입력 프롬프트
+     * @return String Gemini API에 보낼 JSON 요청 문자열
+     * @throws CustomException 요청 바디 직렬화 실패 시
+     */
+    private String buildGeminiRequestBody(String systemPrompt, String userPrompt) {
+        try {
+            String finalPrompt = systemPrompt + "\n\n" + userPrompt;
+            String escapedPrompt = objectMapper.writeValueAsString(finalPrompt);
+
+            return """
+            {
+              "contents": [
+                {
+                  "role": "user",
+                  "parts": [
+                    {
+                      "text": %s
+                    }
+                  ]
+                }
+              ]
+            }
+            """.formatted(escapedPrompt);
+        } catch (JsonProcessingException e) {
+            log.error("[Gemini] 요청 바디 직렬화 실패", e);
+            throw new CustomException(ErrorCode.GEMINI_API_REQUEST_ERROR);
+        }
+    }
+
+    /**
+     * methodName : getGeminiResponseBody
+     * description : 주어진 요청 바디를 기반으로 Gemini API를 호출하고, 응답 바디를 반환한다.
+     *
+     * @param requestBody String 요청 본문 (JSON 형식)
+     * @return String Gemini API의 응답 바디
+     * @throws CustomException 통신 오류 또는 응답 실패 시 예외 발생
+     */
+    private String getGeminiResponseBody(String requestBody) {
+        try {
+            // 헤더 및 요청 설정
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.set("x-goog-api-key", geminiConfig.getApiKey());
+
+            HttpEntity<String> entity = new HttpEntity<>(requestBody, headers);
+
+            // Gemini API 호출
+            ResponseEntity<String> response = restTemplate.exchange(
+                    geminiConfig.getApiUrl(),
+                    HttpMethod.POST,
+                    entity,
+                    String.class
+            );
+
+            // Gemini 응답 파싱
+            return response.getBody();
+
+        } catch (RestClientException e) {
+            log.error("[Gemini] API 호출 실패", e);
+            throw new CustomException(ErrorCode.GEMINI_API_CALL_FAILED);
+        }
+
+    }
+
 }

--- a/be/src/main/java/com/interviewmate/be/infrastructure/openai/dto/GeminiResponse.java
+++ b/be/src/main/java/com/interviewmate/be/infrastructure/openai/dto/GeminiResponse.java
@@ -1,0 +1,32 @@
+package com.interviewmate.be.infrastructure.openai.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+/**
+ * packageName    : com.interviewmate.be.infrastructure.openai.dto
+ * fileName       : GeminiResponse
+ * author         : eumsoli
+ * date           : 2025-04-07
+ * description    : Gemini API 응답 DTO
+ */
+@Schema(description = "Gemini API 응답 DTO")
+public record GeminiResponse(
+
+        @Schema(description = "요약된 제목", example = "갈등 해결 경험")
+        String title,
+
+        @Schema(description = "질문 리스트")
+        List<QuestionItem> questions
+
+) {
+
+    @Schema(description = "질문 항목 DTO")
+    public static record QuestionItem(
+
+            @Schema(description = "면접 질문", example = "갈등 상황에서 팀원과 어떤 방식으로 소통했나요?")
+            String question
+
+    ) {}
+}

--- a/be/src/main/java/com/interviewmate/be/prompt/application/PromptService.java
+++ b/be/src/main/java/com/interviewmate/be/prompt/application/PromptService.java
@@ -30,34 +30,22 @@ public class PromptService {
 
     /**
      * methodName : savePrompt
-     * description : 프롬프트 저장 및 요약 제목 생성 처리
+     * description : Gemini로부터 받은 제목을 포함하여 프롬프트 저장
      *
      * @param user 사용자
-     * @param promptContent 사용자 입력 프롬프트
-     * @return Prompt 저장된 프롬프트 엔티티
+     * @param promptContent 프롬프트 내용
+     * @param title Gemini API로부터 생성된 요약 제목
+     * @return 저장된 Prompt 엔티티
      */
     @Transactional
-    public Prompt savePrompt(User user, String promptContent) {
-        String title = summarizeTitle(promptContent);
-
+    public Prompt savePrompt(User user, String promptContent, String title) {
         Prompt prompt = Prompt.builder()
                 .user(user)
-                .title(title)
                 .prompt(promptContent)
+                .title(title)
                 .build();
 
         return promptRepository.save(prompt);
-    }
-
-    /**
-     * methodName : summarizeTitle
-     * description : 임시 제목 생성 (앞 20자 잘라내기)
-     *
-     * @param prompt 프롬프트 내용
-     * @return 요약된 제목
-     */
-    private String summarizeTitle(String prompt) {
-        return prompt.length() > 20 ? prompt.substring(0, 20) + "..." : prompt;
     }
 
     /**

--- a/be/src/main/java/com/interviewmate/be/prompt/presentation/PromptController.java
+++ b/be/src/main/java/com/interviewmate/be/prompt/presentation/PromptController.java
@@ -7,7 +7,6 @@ import com.interviewmate.be.prompt.application.PromptService;
 import com.interviewmate.be.prompt.dto.PromptListResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -40,11 +39,14 @@ public class PromptController {
      * @param user 로그인 사용자
      * @return ResponseEntity<List<PromptListResponse>> 프롬프트 목록 응답
      */
-    @Operation(summary = "프롬프트 목록 조회", description = "로그인 사용자의 프롬프트 목록을 조회한다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "프롬프트 목록 조회 성공"),
-            @ApiResponse(responseCode = "401", description = "로그인 필요")
-    })
+    @Operation(
+            summary = "프롬프트 목록 조회",
+            description = "로그인 사용자의 프롬프트 목록을 조회한다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "프롬프트 목록 조회 성공"),
+                    @ApiResponse(responseCode = "401", description = "로그인 필요")
+            }
+    )
     @GetMapping
     public ResponseEntity<List<PromptListResponse>> getPromptList(
             @AuthenticationPrincipal User user
@@ -66,13 +68,17 @@ public class PromptController {
      * @param user 로그인 사용자
      * @return ResponseEntity<Void> 204 No Content 응답
      */
-    @Operation(summary = "프롬프트 삭제", description = "프롬프트 및 연결된 질문들을 비활성화한다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "204", description = "삭제 성공"),
-            @ApiResponse(responseCode = "401", description = "로그인 필요"),
-            @ApiResponse(responseCode = "403", description = "본인 소유 프롬프트 아님"),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 프롬프트")
-    })
+    @Operation(
+            summary = "프롬프트 삭제(비활성화)",
+            description = "프롬프트 및 연결된 질문들을 비활성화 처리합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "프롬프트 삭제 성공"),
+                    @ApiResponse(responseCode = "400", description = "이미 비활성화 상태"),
+                    @ApiResponse(responseCode = "401", description = "로그인 필요"),
+                    @ApiResponse(responseCode = "403", description = "다른 사용자의 프롬프트"),
+                    @ApiResponse(responseCode = "404", description = "프롬프트를 찾을 수 없음")
+            }
+    )
     @DeleteMapping("/{promptId}")
     public ResponseEntity<Void> deactivatePrompt(
             @PathVariable Long promptId,

--- a/be/src/main/java/com/interviewmate/be/question/application/QuestionService.java
+++ b/be/src/main/java/com/interviewmate/be/question/application/QuestionService.java
@@ -4,6 +4,8 @@ import com.interviewmate.be.auth.domain.User;
 import com.interviewmate.be.common.exception.CustomException;
 import com.interviewmate.be.common.exception.ErrorCode;
 import com.interviewmate.be.infrastructure.openai.GeminiClient;
+import com.interviewmate.be.infrastructure.openai.dto.GeminiResponse;
+import com.interviewmate.be.infrastructure.openai.dto.GeminiResponse.QuestionItem;
 import com.interviewmate.be.infrastructure.persistence.prompt.PromptRepository;
 import com.interviewmate.be.infrastructure.persistence.question.QuestionRepository;
 import com.interviewmate.be.prompt.application.PromptService;
@@ -47,22 +49,26 @@ public class QuestionService {
     @Transactional
     public List<QuestionResponse> generateQuestions(QuestionGenerateRequest request, User user) {
         // 질문 생성
-        List<String> generated = geminiClient.generateQuestions(request.prompt());
+        GeminiResponse geminiResponse = geminiClient.generateQuestions(request.prompt());
+        String title = geminiResponse.title();
 
-        // 비회원일 경우
-        if(user == null) {
-            return toResponse(generated, 1); // 저장 없이 그대로 응답만
+        List<String> generated = geminiResponse.questions().stream()
+                .map(QuestionItem::question)
+                .toList();
+
+        // 비회원은 저장 없이 응답만
+        if (user == null) {
+            return toResponse(generated, 1);
         }
 
-        // 회원일 경우
-        // 1. 프롬프트 저장
-        Prompt prompt = promptService.savePrompt(user, request.prompt());
+        // 프롬프트 저장 (제목 포함)
+        Prompt prompt = promptService.savePrompt(user, request.prompt(), title);
 
-        // 2. 현재 질문 번호 채번
+        // 질문 번호 채번
         int maxNumber = questionRepository.findMaxNumberByPrompt(prompt);
         int startNumber = maxNumber + 1;
 
-        // 3. 질문 저장
+        // 질문 저장
         List<Question> saved = new ArrayList<>();
 
         for(int i = 0; i < generated.size(); i++) {
@@ -93,7 +99,7 @@ public class QuestionService {
         Question question = questionRepository.findById(questionId)
                 .orElseThrow(() -> new CustomException(ErrorCode.QUESTION_NOT_FOUND));
 
-        // 사용자 자신의 프롬프트인 지 확인
+        // 사용자 자신의 질문인 지 확인
         if (!question.getPrompt().getUser().getId().equals(user.getId())) {
             throw new CustomException(ErrorCode.QUESTION_ACCESS_DENIED);
         }
@@ -113,19 +119,20 @@ public class QuestionService {
      * @param request 질문 재생성 요청 DTO
      * @param user    로그인 사용자
      * @return QuestionResponse 생성된 질문 응답
+     * @throws CustomException 프롬프트 없음, 권한 없음, 재생성 불가 등의 예외 처리
      */
     @Transactional
     public QuestionResponse regenerateQuestion(QuestionRegenerateRequest request, User user) {
         Prompt prompt = promptRepository.findById(request.promptId())
                 .orElseThrow(() -> new CustomException(ErrorCode.PROMPT_NOT_FOUND));
 
+        // 사용자 자신의 프롬프트인 지 확인
         if (!prompt.getUser().getId().equals(user.getId())) {
-            throw new CustomException(ErrorCode.QUESTION_ACCESS_DENIED);
+            throw new CustomException(ErrorCode.PROMPT_ACCESS_DENIED);
         }
 
         // 비활성화된 질문이 존재하는지 확인
         boolean hasInactive = questionRepository.existsByPromptAndIsActiveFalse(prompt);
-
         if (!hasInactive) {
             throw new CustomException(ErrorCode.QUESTION_REGENERATION_NOT_ALLOWED);
         }
@@ -136,8 +143,8 @@ public class QuestionService {
         int maxNumber = questionRepository.findMaxNumberByPrompt(prompt);
         Question question = Question.builder()
                 .prompt(prompt)
-                .question(newQuestion)
                 .number(maxNumber + 1)
+                .question(newQuestion)
                 .build();
 
         Question saved = questionRepository.save(question);
@@ -157,8 +164,9 @@ public class QuestionService {
         Prompt prompt = promptRepository.findById(promptId)
                 .orElseThrow(() -> new CustomException(ErrorCode.PROMPT_NOT_FOUND));
 
+        // 사용자 자신의 프롬프트인 지 확인
         if (!prompt.getUser().getId().equals(user.getId())) {
-            throw new CustomException(ErrorCode.QUESTION_ACCESS_DENIED);
+            throw new CustomException(ErrorCode.PROMPT_ACCESS_DENIED);
         }
 
         List<Question> questions = questionRepository.findAllByPromptAndIsActiveTrueOrderByNumber(prompt);

--- a/be/src/main/java/com/interviewmate/be/question/dto/QuestionGenerateRequest.java
+++ b/be/src/main/java/com/interviewmate/be/question/dto/QuestionGenerateRequest.java
@@ -13,7 +13,7 @@ import jakarta.validation.constraints.NotBlank;
 @Schema(description = "질문 생성 요청 DTO")
 public record QuestionGenerateRequest(
 
-        @Schema(description = "프롬프트 내용", example = "자기소개서 내용을 입력해주세요", required = true)
+        @Schema(description = "프롬프트 내용", example = "자기소개서 내용을 입력해주세요")
         @NotBlank(message = "프롬프트는 필수입니다.")
         String prompt // 사용자 입력 프롬프트 (질문 생성 기준)
 

--- a/be/src/main/java/com/interviewmate/be/question/dto/QuestionRegenerateRequest.java
+++ b/be/src/main/java/com/interviewmate/be/question/dto/QuestionRegenerateRequest.java
@@ -13,7 +13,7 @@ import jakarta.validation.constraints.NotNull;
 @Schema(description = "질문 재생성 요청 DTO")
 public record QuestionRegenerateRequest(
 
-        @Schema(description = "프롬프트 ID", example = "1", required = true)
+        @Schema(description = "프롬프트 ID", example = "1")
         @NotNull(message = "프롬프트 ID는 필수입니다.")
         Long promptId // 재생성할 프롬프트
 

--- a/be/src/main/java/com/interviewmate/be/question/presentation/QuestionController.java
+++ b/be/src/main/java/com/interviewmate/be/question/presentation/QuestionController.java
@@ -10,7 +10,6 @@ import com.interviewmate.be.question.dto.QuestionRegenerateRequest;
 import com.interviewmate.be.question.dto.QuestionResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -31,7 +30,6 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/questions")
 @RequiredArgsConstructor
-@SecurityRequirement(name = "bearerAuth")
 @Tag(name = "Question", description = "질문 관련 API")
 public class QuestionController {
 
@@ -46,17 +44,21 @@ public class QuestionController {
      * @param user    로그인 사용자 (비회원일 경우 null)
      * @return ResponseEntity<List<QuestionResponse>> 생성된 질문 리스트
      */
-    @Operation(summary = "질문 생성", description = "프롬프트를 기반으로 5개의 질문을 생성합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "201", description = "질문 생성 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
-    })
+    @Operation(
+            summary = "질문 생성",
+            description = "프롬프트를 기반으로 5개의 질문을 생성합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "질문 생성 성공"),
+                    @ApiResponse(responseCode = "500", description = "Gemini API 호출 실패")
+            }
+    )
     @PostMapping("/generate")
     public ResponseEntity<List<QuestionResponse>> generateQuestions(
             @RequestBody QuestionGenerateRequest request,
             @AuthenticationPrincipal User user
     ) {
         List<QuestionResponse> responses = questionService.generateQuestions(request, user);
+
         return ResponseEntity.status(HttpStatus.CREATED).body(responses);
     }
 
@@ -64,18 +66,23 @@ public class QuestionController {
      * methodName : deactivateQuestion
      * description : 특정 질문 비활성화(삭제) API
      *
-     * @param questionId 질문 ID (PathVariable)
+     * @param questionId 질문 ID
      * @param user       로그인 사용자
      * @return ResponseEntity<Void> 204 No Content 반환
      * @throws CustomException 질문이 존재하지 않거나 권한이 없는 경우
      */
-    @Operation(summary = "질문 삭제", description = "특정 질문을 비활성화 처리합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "204", description = "질문 삭제 성공"),
-            @ApiResponse(responseCode = "401", description = "로그인 필요"),
-            @ApiResponse(responseCode = "404", description = "질문 ID가 존재하지 않음"),
-            @ApiResponse(responseCode = "403", description = "권한 없음"),
-    })
+    @Operation(
+            summary = "질문 삭제(비활성화)",
+            description = "특정 질문을 비활성화 처리합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "질문 삭제 성공"),
+                    @ApiResponse(responseCode = "400", description = "이미 비활성화 상태"),
+                    @ApiResponse(responseCode = "401", description = "로그인 필요"),
+                    @ApiResponse(responseCode = "403", description = "다른 사용자의 질문"),
+                    @ApiResponse(responseCode = "404", description = "질문을 찾을 수 없음")
+            }
+    )
+    @SecurityRequirement(name = "bearerAuth")
     @DeleteMapping("/{questionId}")
     public ResponseEntity<Void> deactivateQuestion(
             @PathVariable Long questionId,
@@ -86,6 +93,7 @@ public class QuestionController {
         }
 
         questionService.deactivateQuestion(questionId, user);
+
         return ResponseEntity.noContent().build();
     }
 
@@ -97,12 +105,19 @@ public class QuestionController {
      * @param user    로그인 사용자
      * @return ResponseEntity<QuestionResponse> 새로 생성된 질문 응답
      */
-    @Operation(summary = "질문 재생성", description = "비활성화된 질문이 있을 경우 새 질문을 1개 재생성합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "201", description = "질문 재생성 성공"),
-            @ApiResponse(responseCode = "400", description = "모든 질문이 활성 상태거나 잘못된 요청"),
-            @ApiResponse(responseCode = "401", description = "로그인 필요"),
-    })
+    @Operation(
+            summary = "질문 재생성",
+            description = "비활성화된 질문이 있을 경우 새 질문을 1개 재생성합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "질문 재생성 성공"),
+                    @ApiResponse(responseCode = "400", description = "모든 질문이 활성 상태"),
+                    @ApiResponse(responseCode = "401", description = "로그인 필요"),
+                    @ApiResponse(responseCode = "403", description = "다른 사용자의 프롬프트"),
+                    @ApiResponse(responseCode = "404", description = "프롬프트를 찾을 수 없음"),
+                    @ApiResponse(responseCode = "500", description = "Gemini API 호출 실패")
+            }
+    )
+    @SecurityRequirement(name = "bearerAuth")
     @PostMapping("/regenerate")
     public ResponseEntity<QuestionResponse> regenerateQuestion(
             @RequestBody QuestionRegenerateRequest request,
@@ -113,6 +128,7 @@ public class QuestionController {
         }
 
         QuestionResponse response = questionService.regenerateQuestion(request, user);
+
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
@@ -124,12 +140,17 @@ public class QuestionController {
      * @param user     로그인 사용자
      * @return ResponseEntity<QuestionListResponse> 질문 목록 응답
      */
-    @Operation(summary = "질문 목록 조회", description = "프롬프트 ID에 해당하는 활성화된 질문 목록을 조회합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "질문 목록 조회 성공"),
-            @ApiResponse(responseCode = "401", description = "로그인 필요"),
-            @ApiResponse(responseCode = "404", description = "프롬프트가 존재하지 않음"),
-    })
+    @Operation(
+            summary = "질문 목록 조회",
+            description = "프롬프트 ID에 해당하는 활성화된 질문 목록을 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "질문 목록 조회 성공"),
+                    @ApiResponse(responseCode = "401", description = "로그인 필요"),
+                    @ApiResponse(responseCode = "403", description = "다른 사용자의 프롬프트"),
+                    @ApiResponse(responseCode = "404", description = "프롬프트를 찾을 수 없음")
+            }
+    )
+    @SecurityRequirement(name = "bearerAuth")
     @GetMapping("/prompt/{promptId}")
     public ResponseEntity<QuestionListResponse> getQuestions(
             @PathVariable Long promptId,
@@ -140,6 +161,7 @@ public class QuestionController {
         }
 
         QuestionListResponse response = questionService.getActiveQuestions(promptId, user);
+
         return ResponseEntity.ok(response);
     }
 

--- a/be/src/test/java/com/interviewmate/be/question/application/QuestionServiceTest.java
+++ b/be/src/test/java/com/interviewmate/be/question/application/QuestionServiceTest.java
@@ -4,6 +4,8 @@ import com.interviewmate.be.auth.domain.User;
 import com.interviewmate.be.common.exception.CustomException;
 import com.interviewmate.be.common.exception.ErrorCode;
 import com.interviewmate.be.infrastructure.openai.GeminiClient;
+import com.interviewmate.be.infrastructure.openai.dto.GeminiResponse;
+import com.interviewmate.be.infrastructure.openai.dto.GeminiResponse.QuestionItem;
 import com.interviewmate.be.infrastructure.persistence.prompt.PromptRepository;
 import com.interviewmate.be.infrastructure.persistence.question.QuestionRepository;
 import com.interviewmate.be.prompt.application.PromptService;
@@ -92,16 +94,15 @@ class QuestionServiceTest {
     @DisplayName("비회원이 질문 생성 요청 시 저장 없이 결과만 응답한다")
     void generateQuestions_GuestUser_ReturnsQuestionsWithoutSaving() {
         // Given
-        List<String> generated = List.of("질문 1", "질문 2", "질문 3");
-        given(geminiClient.generateQuestions("프롬프트")).willReturn(generated);
-
+        GeminiResponse mockGeminiResponse = new GeminiResponse("제목", List.of(new QuestionItem("질문 1"), new QuestionItem("질문 2")));
+        given(geminiClient.generateQuestions("프롬프트")).willReturn(mockGeminiResponse);
         QuestionGenerateRequest request = new QuestionGenerateRequest("프롬프트");
 
         // When
         List<QuestionResponse> result = questionService.generateQuestions(request, null);
 
         // Then
-        assertThat(result).hasSize(3);
+        assertThat(result).hasSize(2);
         assertThat(result.get(0).question()).isEqualTo("질문 1");
         verify(questionRepository, never()).save(any());
     }
@@ -110,9 +111,9 @@ class QuestionServiceTest {
     @DisplayName("회원이 질문 생성 요청 시 프롬프트와 질문을 저장하고 응답한다")
     void generateQuestions_AuthenticatedUser_SavesPromptAndQuestions() {
         // Given
-        List<String> generated = List.of("질문 A", "질문 B");
-        given(geminiClient.generateQuestions(any())).willReturn(generated);
-        given(promptService.savePrompt(eq(mockUser), any())).willReturn(mockPrompt);
+        GeminiResponse mockGeminiResponse = new GeminiResponse("제목", List.of(new QuestionItem("질문 1"), new QuestionItem("질문 2")));
+        given(geminiClient.generateQuestions(any())).willReturn(mockGeminiResponse);
+        given(promptService.savePrompt(eq(mockUser), any(), any())).willReturn(mockPrompt);
         given(questionRepository.findMaxNumberByPrompt(mockPrompt)).willReturn(0);
         given(questionRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
 
@@ -124,7 +125,7 @@ class QuestionServiceTest {
         // Then
         assertThat(result).hasSize(2);
         assertThat(result.get(1).number()).isEqualTo(2);
-        assertThat(result.get(1).question()).isEqualTo("질문 B");
+        assertThat(result.get(1).question()).isEqualTo("질문 2");
         verify(questionRepository, times(2)).save(any());
     }
 

--- a/swagger.json
+++ b/swagger.json
@@ -1,0 +1,641 @@
+{
+  "openapi":"3.0.1",
+  "info":{
+    "title":"인터뷰 메이트 API",
+    "description":"인터뷰 메이트 API 명세서",
+    "version":"v1.0"
+  },
+  "servers":[
+    {
+      "url":"http://localhost:8080",
+      "description":"로컬 서버"
+    }
+  ],
+  "security":[
+    {
+      "bearerAuth":[
+      ]
+    }
+  ],
+  "tags":[
+    {
+      "name":"Question",
+      "description":"질문 관련 API"
+    },
+    {
+      "name":"User",
+      "description":"사용자 관련 API"
+    },
+    {
+      "name":"Prompt",
+      "description":"프롬프트 관련 API"
+    },
+    {
+      "name":"Auth",
+      "description":"JWT 인증 관련 API"
+    }
+  ],
+  "paths":{
+    "/api/questions/regenerate":{
+      "post":{
+        "tags":[
+          "Question"
+        ],
+        "summary":"질문 재생성",
+        "description":"비활성화된 질문이 있을 경우 새 질문을 1개 재생성합니다.",
+        "operationId":"regenerateQuestion",
+        "requestBody":{
+          "content":{
+            "application/json":{
+              "schema":{
+                "$ref":"#/components/schemas/QuestionRegenerateRequest"
+              }
+            }
+          },
+          "required":true
+        },
+        "responses":{
+          "201":{
+            "description":"질문 재생성 성공",
+            "content":{
+              "*/*":{
+                "schema":{
+                  "$ref":"#/components/schemas/QuestionResponse"
+                }
+              }
+            }
+          },
+          "400":{
+            "description":"모든 질문이 활성 상태",
+            "content":{
+              "*/*":{
+                "schema":{
+                  "$ref":"#/components/schemas/QuestionResponse"
+                }
+              }
+            }
+          },
+          "401":{
+            "description":"로그인 필요",
+            "content":{
+              "*/*":{
+                "schema":{
+                  "$ref":"#/components/schemas/QuestionResponse"
+                }
+              }
+            }
+          },
+          "403":{
+            "description":"다른 사용자의 프롬프트",
+            "content":{
+              "*/*":{
+                "schema":{
+                  "$ref":"#/components/schemas/QuestionResponse"
+                }
+              }
+            }
+          },
+          "404":{
+            "description":"프롬프트를 찾을 수 없음",
+            "content":{
+              "*/*":{
+                "schema":{
+                  "$ref":"#/components/schemas/QuestionResponse"
+                }
+              }
+            }
+          },
+          "500":{
+            "description":"Gemini API 호출 실패",
+            "content":{
+              "*/*":{
+                "schema":{
+                  "$ref":"#/components/schemas/QuestionResponse"
+                }
+              }
+            }
+          }
+        },
+        "security":[
+          {
+            "bearerAuth":[
+            ]
+          }
+        ]
+      }
+    },
+    "/api/questions/generate":{
+      "post":{
+        "tags":[
+          "Question"
+        ],
+        "summary":"질문 생성",
+        "description":"프롬프트를 기반으로 5개의 질문을 생성합니다.",
+        "operationId":"generateQuestions",
+        "requestBody":{
+          "content":{
+            "application/json":{
+              "schema":{
+                "$ref":"#/components/schemas/QuestionGenerateRequest"
+              }
+            }
+          },
+          "required":true
+        },
+        "responses":{
+          "201":{
+            "description":"질문 생성 성공",
+            "content":{
+              "*/*":{
+                "schema":{
+                  "type":"array",
+                  "items":{
+                    "$ref":"#/components/schemas/QuestionResponse"
+                  }
+                }
+              }
+            }
+          },
+          "500":{
+            "description":"Gemini API 호출 실패",
+            "content":{
+              "*/*":{
+                "schema":{
+                  "type":"array",
+                  "items":{
+                    "$ref":"#/components/schemas/QuestionResponse"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/auth/refresh":{
+      "post":{
+        "tags":[
+          "Auth"
+        ],
+        "summary":"Access Token 재발급",
+        "description":"Refresh Token을 이용하여 새로운 Access Token을 발급합니다.",
+        "operationId":"refreshAccessToken",
+        "requestBody":{
+          "description":"Refresh Token 요청 객체",
+          "content":{
+            "application/json":{
+              "schema":{
+                "$ref":"#/components/schemas/RefreshTokenRequest"
+              }
+            }
+          }
+        },
+        "responses":{
+          "200":{
+            "description":"Access Token 재발급 성공",
+            "content":{
+              "*/*":{
+                "schema":{
+                  "type":"object",
+                  "additionalProperties":{
+                    "type":"string"
+                  }
+                }
+              }
+            }
+          },
+          "401":{
+            "description":"유효하지 않은 Refresh Token",
+            "content":{
+              "*/*":{
+                "schema":{
+                  "type":"object",
+                  "additionalProperties":{
+                    "type":"string"
+                  }
+                }
+              }
+            }
+          },
+          "404":{
+            "description":"Refresh Token을 찾을 수 없음",
+            "content":{
+              "*/*":{
+                "schema":{
+                  "type":"object",
+                  "additionalProperties":{
+                    "type":"string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/auth/logout":{
+      "post":{
+        "tags":[
+          "Auth"
+        ],
+        "summary":"로그아웃",
+        "description":"현재 사용자의 Refresh Token을 삭제하여 로그아웃 처리합니다.\n클라이언트는 응답을 받으면 Access Token 및 Refresh Token을 삭제해야 합니다.\n",
+        "operationId":"logout",
+        "responses":{
+          "204":{
+            "description":"로그아웃 성공"
+          },
+          "401":{
+            "description":"인증되지 않은 사용자"
+          }
+        },
+        "security":[
+          {
+            "bearerAuth":[
+            ]
+          }
+        ]
+      }
+    },
+    "/api/user/me":{
+      "get":{
+        "tags":[
+          "User"
+        ],
+        "summary":"현재 로그인된 사용자 정보 조회",
+        "description":"JWT Access Token을 기반으로 현재 로그인한 사용자의 정보를 반환합니다.",
+        "operationId":"getCurrentUser",
+        "responses":{
+          "200":{
+            "description":"사용자 정보 조회 성공",
+            "content":{
+              "*/*":{
+                "schema":{
+                  "type":"object",
+                  "additionalProperties":{
+                    "type":"object"
+                  }
+                }
+              }
+            }
+          },
+          "401":{
+            "description":"인증되지 않은 사용자",
+            "content":{
+              "*/*":{
+                "schema":{
+                  "type":"object",
+                  "additionalProperties":{
+                    "type":"object"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security":[
+          {
+            "bearerAuth":[
+            ]
+          }
+        ]
+      }
+    },
+    "/api/questions/prompt/{promptId}":{
+      "get":{
+        "tags":[
+          "Question"
+        ],
+        "summary":"질문 목록 조회",
+        "description":"프롬프트 ID에 해당하는 활성화된 질문 목록을 조회합니다.",
+        "operationId":"getQuestions",
+        "parameters":[
+          {
+            "name":"promptId",
+            "in":"path",
+            "required":true,
+            "schema":{
+              "type":"integer",
+              "format":"int64"
+            }
+          }
+        ],
+        "responses":{
+          "200":{
+            "description":"질문 목록 조회 성공",
+            "content":{
+              "*/*":{
+                "schema":{
+                  "$ref":"#/components/schemas/QuestionListResponse"
+                }
+              }
+            }
+          },
+          "401":{
+            "description":"로그인 필요",
+            "content":{
+              "*/*":{
+                "schema":{
+                  "$ref":"#/components/schemas/QuestionListResponse"
+                }
+              }
+            }
+          },
+          "403":{
+            "description":"다른 사용자의 프롬프트",
+            "content":{
+              "*/*":{
+                "schema":{
+                  "$ref":"#/components/schemas/QuestionListResponse"
+                }
+              }
+            }
+          },
+          "404":{
+            "description":"프롬프트를 찾을 수 없음",
+            "content":{
+              "*/*":{
+                "schema":{
+                  "$ref":"#/components/schemas/QuestionListResponse"
+                }
+              }
+            }
+          }
+        },
+        "security":[
+          {
+            "bearerAuth":[
+            ]
+          }
+        ]
+      }
+    },
+    "/api/prompts":{
+      "get":{
+        "tags":[
+          "Prompt"
+        ],
+        "summary":"프롬프트 목록 조회",
+        "description":"로그인 사용자의 프롬프트 목록을 조회한다.",
+        "operationId":"getPromptList",
+        "responses":{
+          "200":{
+            "description":"프롬프트 목록 조회 성공",
+            "content":{
+              "*/*":{
+                "schema":{
+                  "type":"array",
+                  "items":{
+                    "$ref":"#/components/schemas/PromptListResponse"
+                  }
+                }
+              }
+            }
+          },
+          "401":{
+            "description":"로그인 필요",
+            "content":{
+              "*/*":{
+                "schema":{
+                  "type":"array",
+                  "items":{
+                    "$ref":"#/components/schemas/PromptListResponse"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security":[
+          {
+            "bearerAuth":[
+            ]
+          }
+        ]
+      }
+    },
+    "/api/user":{
+      "delete":{
+        "tags":[
+          "User"
+        ],
+        "summary":"회원 탈퇴",
+        "description":"현재 로그인한 사용자를 DB에서 삭제하고, Redis에서 해당 사용자의 Refresh Token을 제거합니다.\n클라이언트는 응답을 받으면 Access Token과 Refresh Token을 삭제하고 로그인 화면으로 이동해야 합니다.\n",
+        "operationId":"deleteUser",
+        "responses":{
+          "204":{
+            "description":"회원 탈퇴 및 로그아웃 성공"
+          },
+          "401":{
+            "description":"인증되지 않은 사용자"
+          },
+          "404":{
+            "description":"사용자를 찾을 수 없음"
+          }
+        },
+        "security":[
+          {
+            "bearerAuth":[
+            ]
+          }
+        ]
+      }
+    },
+    "/api/questions/{questionId}":{
+      "delete":{
+        "tags":[
+          "Question"
+        ],
+        "summary":"질문 삭제(비활성화)",
+        "description":"특정 질문을 비활성화 처리합니다.",
+        "operationId":"deactivateQuestion",
+        "parameters":[
+          {
+            "name":"questionId",
+            "in":"path",
+            "required":true,
+            "schema":{
+              "type":"integer",
+              "format":"int64"
+            }
+          }
+        ],
+        "responses":{
+          "204":{
+            "description":"질문 삭제 성공"
+          },
+          "400":{
+            "description":"이미 비활성화 상태"
+          },
+          "401":{
+            "description":"로그인 필요"
+          },
+          "403":{
+            "description":"다른 사용자의 질문"
+          },
+          "404":{
+            "description":"질문을 찾을 수 없음"
+          }
+        },
+        "security":[
+          {
+            "bearerAuth":[
+            ]
+          }
+        ]
+      }
+    },
+    "/api/prompts/{promptId}":{
+      "delete":{
+        "tags":[
+          "Prompt"
+        ],
+        "summary":"프롬프트 삭제(비활성화)",
+        "description":"프롬프트 및 연결된 질문들을 비활성화 처리합니다.",
+        "operationId":"deactivatePrompt",
+        "parameters":[
+          {
+            "name":"promptId",
+            "in":"path",
+            "required":true,
+            "schema":{
+              "type":"integer",
+              "format":"int64"
+            }
+          }
+        ],
+        "responses":{
+          "204":{
+            "description":"프롬프트 삭제 성공"
+          },
+          "400":{
+            "description":"이미 비활성화 상태"
+          },
+          "401":{
+            "description":"로그인 필요"
+          },
+          "403":{
+            "description":"다른 사용자의 프롬프트"
+          },
+          "404":{
+            "description":"프롬프트를 찾을 수 없음"
+          }
+        },
+        "security":[
+          {
+            "bearerAuth":[
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "components":{
+    "schemas":{
+      "QuestionRegenerateRequest":{
+        "required":[
+          "promptId"
+        ],
+        "type":"object",
+        "properties":{
+          "promptId":{
+            "type":"integer",
+            "description":"프롬프트 ID",
+            "format":"int64",
+            "example":1
+          }
+        },
+        "description":"질문 재생성 요청 DTO"
+      },
+      "QuestionResponse":{
+        "type":"object",
+        "properties":{
+          "number":{
+            "type":"integer",
+            "description":"질문 번호",
+            "format":"int32",
+            "example":1
+          },
+          "question":{
+            "type":"string",
+            "description":"질문 내용",
+            "example":"이 프로젝트에서 맡은 역할은 무엇인가요?"
+          }
+        },
+        "description":"질문 응답 DTO"
+      },
+      "QuestionGenerateRequest":{
+        "required":[
+          "prompt"
+        ],
+        "type":"object",
+        "properties":{
+          "prompt":{
+            "type":"string",
+            "description":"프롬프트 내용",
+            "example":"자기소개서 내용을 입력해주세요"
+          }
+        },
+        "description":"질문 생성 요청 DTO"
+      },
+      "RefreshTokenRequest":{
+        "type":"object",
+        "properties":{
+          "refreshToken":{
+            "type":"string",
+            "description":"사용자의 Refresh Token",
+            "example":"eyJhbGciOiJIUzI1..."
+          }
+        },
+        "description":"Access Token 재발급 요청 DTO"
+      },
+      "QuestionListResponse":{
+        "type":"object",
+        "properties":{
+          "questions":{
+            "type":"array",
+            "description":"질문 리스트",
+            "items":{
+              "$ref":"#/components/schemas/QuestionResponse"
+            }
+          }
+        },
+        "description":"질문 목록 조회 응답 DTO"
+      },
+      "PromptListResponse":{
+        "type":"object",
+        "properties":{
+          "promptId":{
+            "type":"integer",
+            "description":"프롬프트 ID",
+            "format":"int64",
+            "example":1
+          },
+          "title":{
+            "type":"string",
+            "description":"프롬프트 제목",
+            "example":"AI 면접 질문 생성"
+          },
+          "prompt":{
+            "type":"string",
+            "description":"프롬프트 내용",
+            "example":"AI를 활용해 자기소개 질문 5개를 만들어줘"
+          },
+          "createdAt":{
+            "type":"string",
+            "description":"프롬프트 생성일",
+            "format":"date-time"
+          }
+        },
+        "description":"프롬프트 목록 조회 응답 DTO"
+      }
+    },
+    "securitySchemes":{
+      "bearerAuth":{
+        "type":"http",
+        "scheme":"bearer",
+        "bearerFormat":"JWT"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## ✨ PR 요약

Gemini API를 연동하여 프롬프트 기반 면접 질문 5개와 요약 제목을 생성하는 기능을 구현했습니다.
프롬프트 입력 → Gemini 호출 → 질문/제목 생성 → 저장 및 응답의 전체 흐름을 완성했습니다.

---

## 📌 구현 내용

- Gemini API 연동 및 설정 클래스 (`GeminiConfig`)
- 질문 5개 + 제목 생성 (`generateQuestions`)
- 단일 질문 재생성 (`generateSingleQuestion`) 기본 구조 포함
- 백틱 문제 해결을 위한 전처리 (`replaceAll`) 및 프롬프트 문구 개선
- 질문 저장 시 promptService 및 questionRepository 활용
- 예외 처리: 응답 파싱, 통신 실패에 대한 CustomException 적용
- Swagger 문서화 (`@Operation`, `@ApiResponse` 등)
- 단위 테스트 및 통합 테스트 코드 작성

---

## ✅ 체크리스트

- [x] Gemini 응답 파싱 정상 작동 확인
- [x] 질문 및 프롬프트 저장 정상 작동 확인
- [x] Swagger 명세 확인
- [x] 테스트 코드 작성 및 통과

---

## 🎯 관련 이슈

Resolves: #16
