### PR TITLE
docs : YAML 문법 수정

### DIFF
--- a/be/src/main/java/com/interviewmate/be/BeApplication.java
+++ b/be/src/main/java/com/interviewmate/be/BeApplication.java
@@ -1,11 +1,8 @@
 package com.interviewmate.be;
 
-import io.github.cdimascio.dotenv.Dotenv;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableScheduling;
-
-import java.io.File;
 
 @EnableScheduling
 @SpringBootApplication

--- a/be/src/main/resources/config/application-security.yml
+++ b/be/src/main/resources/config/application-security.yml
@@ -11,14 +11,14 @@ spring:
           google:
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
-            redirect-uri: http://localhost:8080/login/oauth2/code/google # 인증 후 사용자가 리디렉션될 URI
+            redirect-uri: "{baseUrl}/login/oauth2/callback/google" # 인증 후 사용자가 리디렉션될 URI
             scope: # google API의 범위 값
               - profile
               - email
           kakao:
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_CLIENT_SECRET}
-            redirect-uri: http://localhost:8080/login/oauth2/code/kakao # {baseUrl} : http://localhost:8080
+            redirect-uri: "{baseUrl}/login/oauth2/callback/kakao"
             client-authentication-method: client_secret_post
             authorization-grant-type: authorization_code
             scope: # kakao 개인 정보 동의 항목 설정의 ID 값


### PR DESCRIPTION
구글/카카오 로그인 기능을 위한 OAuth2 클라이언트 설정을 추가
redirect-uri 설정 시 YAML 파싱 오류를 방지하기 위해 큰따옴표로 감싸는 방식으로 수정

- {baseUrl} 기반 redirect-uri 경로 설정