### PR TITLE
feat: Redis 설정을 URL 기반으로 변경

### DIFF
--- a/be/src/main/java/com/interviewmate/be/common/config/RedisConfig.java
+++ b/be/src/main/java/com/interviewmate/be/common/config/RedisConfig.java
@@ -18,26 +18,24 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @Configuration
 public class RedisConfig {
 
-    private final String redisHost;
-    private final int redisPort;
+    private final String redisUrl;
 
     public RedisConfig(
-            @Value("${spring.data.redis.host}") String redisHost,
-            @Value("${spring.data.redis.port}") int redisPort
+            @Value("${spring.data.redis.url}") String redisUrl
     ) {
-        this.redisHost = redisHost;
-        this.redisPort = redisPort;
+        this.redisUrl = redisUrl;
     }
 
     /**
      * methodName : redisConnectionFactory
-     * description : Redis 연결 팩토리 설정
+     * description : Redis 연결 팩토리 설정 (URL 기반)
      *
      * @return RedisConnectionFactory Redis 연결 팩토리 객체
      */
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(redisHost, redisPort);
+        return new LettuceConnectionFactory(
+                LettuceConnectionFactory.createRedisConfiguration(redisUrl));
     }
 
     /**

--- a/be/src/main/resources/config/application-database.yml
+++ b/be/src/main/resources/config/application-database.yml
@@ -4,15 +4,15 @@ spring:
     url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
+
   jpa:
     show-sql: true # 콘솔에 SQL 쿼리를 출력할지 여부를 결정
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
     properties:
       hibernate:
         format_sql: true # SQL 쿼리를 보기 좋게 포맷팅
-        dialect: org.hibernate.dialect.PostgreSQLDialect
+
   data:
     redis:
-      host: localhost
-      port: ${REDIS_PORT}
+      url: ${REDIS_URL:redis://localhost:6379}

--- a/be/src/main/resources/config/application-security.yml
+++ b/be/src/main/resources/config/application-security.yml
@@ -54,7 +54,7 @@ spring:
             redirect-uri: "http://localhost:8080/login/oauth2/code/kakao"
 
 ---
-# 프로덕션 환경 설정
+# 개발 환경 설정
 spring:
   config:
     activate:


### PR DESCRIPTION
- Redis 연결 구성을 호스트/포트 방식에서 URL 방식으로 변경
- RedisConfig 클래스를 URL 기반 연결을 지원하도록 수정
- 로컬 및 클라우드 환경 모두 동일한 구성 사용 가능
- Render 클라우드 서비스 호환성 개선