### PR TITLE
feat: 헤더 컴포넌트 및 인증 기능 추가

### DIFF
--- a/fe/src/app/layout.tsx
+++ b/fe/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { AuthProvider } from "@/hooks/useAuth";
+import Header from "@/layouts/Header";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +29,10 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <AuthProvider>
+          <Header />
+          <main>{children}</main>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/fe/src/app/layout.tsx
+++ b/fe/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { AuthProvider } from "@/hooks/useAuth";
 import Header from "@/layouts/Header";
+import ClientSidebar from "@/layouts/Sidebar";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -31,7 +32,10 @@ export default function RootLayout({
       >
         <AuthProvider>
           <Header />
-          <main>{children}</main>
+          <div className="flex h-[calc(100vh-64px)]">
+            <ClientSidebar />
+            <main className="flex-1 overflow-auto">{children}</main>
+          </div>
         </AuthProvider>
       </body>
     </html>

--- a/fe/src/components/Record/RecordingButton.tsx
+++ b/fe/src/components/Record/RecordingButton.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import clsx from "clsx";
-import Button from "../common/Button/Button";
+import { Button } from "../ui/button";
 import { RecordingState, useRecording } from "@/hooks/useRecording";
 
 interface RecordingButtonProps {

--- a/fe/src/components/layout/Sidebar/List.tsx
+++ b/fe/src/components/layout/Sidebar/List.tsx
@@ -1,30 +1,36 @@
 "use client";
 
-import { ReactNode } from "react";
+import React, { HTMLAttributes, ReactNode } from "react";
 
-interface ListItemProps {
+interface ListProps extends HTMLAttributes<HTMLUListElement> {
   children: ReactNode;
-  className?: string;
-  onClick?: () => void;
 }
+
+interface ListItemProps extends HTMLAttributes<HTMLLIElement> {
+  children: ReactNode;
+}
+
+export const List = ({ children, className = "", ...rest }: ListProps) => {
+  return (
+    <ul className={`list-none p-0 m-0 ${className}`} {...rest}>
+      {children}
+    </ul>
+  );
+};
 
 export const ListItem = ({
   children,
   className = "",
   onClick,
-}: ListItemProps) => (
-  <div
-    className={`flex items-center p-2 hover:bg-gray-100 rounded-lg cursor-pointer ${className}`}
-    onClick={onClick}
-  >
-    {children}
-  </div>
-);
-
-export const List = ({
-  children,
-  className = "",
-}: {
-  children: ReactNode;
-  className?: string;
-}) => <div className={`space-y-1 ${className}`}>{children}</div>;
+  ...rest
+}: ListItemProps) => {
+  return (
+    <li
+      className={`cursor-pointer truncate ${className}`}
+      onClick={onClick}
+      {...rest}
+    >
+      {children}
+    </li>
+  );
+};

--- a/fe/src/components/layout/Sidebar/Sidebar.tsx
+++ b/fe/src/components/layout/Sidebar/Sidebar.tsx
@@ -1,31 +1,64 @@
 "use client";
 
+import React from "react";
 import { List, ListItem } from "./List";
+import SidebarButton from "./SidebarButton";
+
+interface Post {
+  id: string;
+  title: string;
+  date: string;
+}
 
 interface SidebarProps {
   onAddPost?: () => void;
-  posts: Array<{ id: string; title: string }>;
+  posts: Array<Post>;
   onPostClick?: (id: string) => void;
 }
 
 export const Sidebar = ({ onAddPost, posts, onPostClick }: SidebarProps) => {
+  const groupedPosts = posts.reduce<Record<string, Post[]>>((groups, post) => {
+    const { date } = post;
+    if (!groups[date]) {
+      groups[date] = [];
+    }
+    groups[date].push(post);
+    return groups;
+  }, {});
+
   return (
-    <div className="p-4 flex flex-col gap-4">
-      {onAddPost && (
-        <button
-          onClick={onAddPost}
-          className="w-full p-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600"
-        >
-          포폴 추가하기
-        </button>
-      )}
-      <List>
-        {posts.map((post) => (
-          <ListItem key={post.id} onClick={() => onPostClick?.(post.id)}>
-            <span className="text-sm">{post.title}</span>
-          </ListItem>
+    <div className="border-r border-gray-200 h-screen flex flex-col">
+      <div className="p-4">
+        {onAddPost && (
+          <SidebarButton
+            onClick={onAddPost}
+            text="포폴 추가하기"
+            iconSrc="/images/icons/sidebar_icon.svg"
+            className="bg-yellow-300 hover:bg-yellow-400 text-white"
+          />
+        )}
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-4">
+        {Object.entries(groupedPosts).map(([date, datePosts]) => (
+          <div key={date} className="mb-4">
+            <h3 className="text-sm font-medium text-gray-600 mb-2">{date}</h3>
+            <List>
+              {datePosts.map((post) => (
+                <ListItem
+                  key={post.id}
+                  onClick={() => onPostClick?.(post.id)}
+                  className="py-2 px-0 hover:bg-gray-100"
+                >
+                  <span className="text-sm text-gray-700 truncate">
+                    {post.title}
+                  </span>
+                </ListItem>
+              ))}
+            </List>
+          </div>
         ))}
-      </List>
+      </div>
     </div>
   );
 };

--- a/fe/src/components/layout/Sidebar/Sidebar.tsx
+++ b/fe/src/components/layout/Sidebar/Sidebar.tsx
@@ -16,7 +16,7 @@ export const Sidebar = ({ onAddPost, posts, onPostClick }: SidebarProps) => {
           onClick={onAddPost}
           className="w-full p-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600"
         >
-          포스트 추가하기
+          포폴 추가하기
         </button>
       )}
       <List>

--- a/fe/src/hooks/useAuth.tsx
+++ b/fe/src/hooks/useAuth.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import {
+  useState,
+  ReactNode,
+  useContext,
+  useCallback,
+  ReactElement,
+  createContext,
+} from "react";
+
+interface User {
+  id: string;
+  email: string;
+  name: string;
+}
+
+interface LoginCredentials {
+  email: string;
+  password: string;
+}
+
+interface AuthContextType {
+  isAuthenticated: boolean;
+  user: User | null;
+  checkAuthStatus: () => Promise<boolean>;
+  login: (credentials: LoginCredentials) => Promise<boolean>;
+  logout: () => Promise<void>;
+}
+
+const defaultAuthContext: AuthContextType = {
+  isAuthenticated: false,
+  user: null,
+  checkAuthStatus: async () => false,
+  login: async () => false,
+  logout: async () => {},
+};
+
+const AuthContext = createContext<AuthContextType>(defaultAuthContext);
+
+export function AuthProvider({
+  children,
+}: {
+  children: ReactNode;
+}): ReactElement {
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false);
+  const [user, setUser] = useState<User | null>(null);
+
+  const checkAuthStatus = useCallback(async (): Promise<boolean> => {
+    if (typeof window === "undefined") return false;
+
+    // TODO: 로컬 스토리지 -> 쿠키 / 세션
+    try {
+      const storedUser = localStorage.getItem("userInfo");
+      if (!storedUser) {
+        setUser(null);
+        setIsAuthenticated(false);
+        return false;
+      }
+
+      const parsedUser = JSON.parse(storedUser) as User;
+      setUser(parsedUser);
+      setIsAuthenticated(true);
+      return true;
+    } catch (error) {
+      console.error("인증 상태 확인 중 오류 발생:", error);
+      setUser(null);
+      setIsAuthenticated(false);
+      return false;
+    }
+  }, []);
+
+  const login = useCallback(
+    async (credentials: LoginCredentials): Promise<boolean> => {
+      if (typeof window === "undefined") return false;
+
+      // 목업 데이터
+      try {
+        const mockUser: User = {
+          id: "user-1",
+          email: credentials.email,
+          name: "사용자",
+        };
+
+        localStorage.setItem("userInfo", JSON.stringify(mockUser));
+        setUser(mockUser);
+        setIsAuthenticated(true);
+        return true;
+      } catch (error) {
+        console.error("로그인 중 오류 발생:", error);
+        return false;
+      }
+    },
+    []
+  );
+
+  const logout = useCallback(async (): Promise<void> => {
+    if (typeof window === "undefined") return;
+
+    try {
+      localStorage.removeItem("userInfo");
+      setUser(null);
+      setIsAuthenticated(false);
+    } catch (error) {
+      console.error("로그아웃 중 오류 발생:", error);
+    }
+  }, []);
+
+  return (
+    <AuthContext.Provider
+      value={{ isAuthenticated, user, checkAuthStatus, login, logout }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth(): AuthContextType {
+  return useContext(AuthContext);
+}

--- a/fe/src/layouts/Header.tsx
+++ b/fe/src/layouts/Header.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import React, { useEffect } from "react";
+import Link from "next/link";
+import Image from "next/image";
+import { useAuth } from "@/hooks/useAuth";
+import LoginButton from "@/components/layout/Header/LoginButton";
+import SignupButton from "@/components/layout/Header/SignupButton";
+
+export default function Header() {
+  const { isAuthenticated, checkAuthStatus } = useAuth();
+
+  useEffect(() => {
+    checkAuthStatus();
+  }, [checkAuthStatus]);
+
+  return (
+    <header className="w-full flex items-center justify-between px-6 py-4 border-b border-gray-200">
+      <div className="flex items-center">
+        <Link href="/" aria-label="홈으로 이동">
+          <Image
+            src="/images/icons/interview_mate_logo.svg"
+            alt="Interview Mate"
+            width={120}
+            height={24}
+            priority
+          />
+        </Link>
+      </div>
+
+      {!isAuthenticated && (
+        <nav className="flex items-center gap-2">
+          <LoginButton
+            onClick={() => console.log("로그인 버튼 클릭")}
+            aria-label="로그인"
+          />
+          <SignupButton
+            onClick={() => console.log("회원가입 버튼 클릭")}
+            aria-label="회원가입"
+          />
+        </nav>
+      )}
+    </header>
+  );
+}

--- a/fe/src/layouts/Sidebar.tsx
+++ b/fe/src/layouts/Sidebar.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import React from "react";
+import { useRouter } from "next/navigation";
+import { Sidebar } from "@/components";
+
+// 목업 데이터
+const mockPosts = [
+  {
+    id: "1",
+    title: "React로 CMS를 작업하였고, ...",
+    date: "오늘",
+  },
+  {
+    id: "2",
+    title: "React로 CMS를 작업하였고, ...",
+    date: "오늘",
+  },
+  {
+    id: "3",
+    title: "Next.js와 Tailwind로 포트폴리오 사이트 만들기",
+    date: "어제",
+  },
+  {
+    id: "4",
+    title: "TypeScript 타입 시스템 활용하기",
+    date: "어제",
+  },
+  {
+    id: "5",
+    title: "반응형 디자인 구현하기",
+    date: "지난주",
+  },
+];
+
+export default function ClientSidebar() {
+  const router = useRouter();
+
+  const handleAddPost = () => {
+    router.push("/portfolio/new");
+  };
+
+  const handlePostClick = (id: string) => {
+    router.push(`/portfolio/${id}`);
+  };
+
+  return (
+    <div className="w-64 flex-shrink-0">
+      <Sidebar
+        posts={mockPosts}
+        onAddPost={handleAddPost}
+        onPostClick={handlePostClick}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## 변경 사항

- 재사용 가능한 헤더 컴포넌트 구현
- localStorage 기반 인증 컨텍스트 및 훅 개발
- 루트 레이아웃에 헤더 통합으로 전체 앱에 표시
- 로그인/회원가입 버튼 및 조건부 렌더링 구현

## 테스트 방법
1. 로컬 환경에서 애플리케이션 실행
2. 헤더에 로그인/회원가입 버튼이 표시되는지 확인
3. 로컬 스토리지에 userInfo 추가 후 새로고침하여 인증 상태 변경 확인

## 추가 정보
- 추후에 Storybook 도입 예정이며, 해당 컴포넌트들의 스토리 파일도 작성할 계획입니다.