### PR TITLE
fix : OAuth2 로그인 성공 후 JSON 반환 방식 → 리디렉트 방식으로 수정

### DIFF
--- a/be/src/main/java/com/interviewmate/be/auth/event/OAuth2SuccessHandler.java
+++ b/be/src/main/java/com/interviewmate/be/auth/event/OAuth2SuccessHandler.java
@@ -1,6 +1,5 @@
 package com.interviewmate.be.auth.event;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.interviewmate.be.auth.application.TokenService;
 import com.interviewmate.be.auth.domain.OAuth2UserInfo;
 import com.interviewmate.be.auth.domain.OAuth2UserInfoFactory;
@@ -14,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -33,7 +33,6 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final TokenService tokenService;
-    private final ObjectMapper objectMapper = new ObjectMapper();
 
     /**
      * methodName : onAuthenticationSuccess
@@ -70,14 +69,23 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         // Refresh Token을 Redis에 저장
         tokenService.saveRefreshToken(userInfo.getId(), refreshToken);
 
-        Map<String, String> tokenResponse = new HashMap<>();
-        tokenResponse.put("accessToken", accessToken);
-        tokenResponse.put("refreshToken", refreshToken);
+        // TODO: 실제 프론트 도메인 주소로 교체
+        String frontendBaseUri = "http://localhost:3000";
+        String callbackPath = switch (provider.toLowerCase()) {
+            case "google" -> "/api/auth/callback/google";
+            case "kakao" -> "/api/auth/callback/kakao";
+            default -> "/"; // fallback
+        };
 
-        // JSON 형태로 응답
-        response.setContentType("application/json");
-        response.setCharacterEncoding("UTF-8");
-        response.getWriter().write(objectMapper.writeValueAsString(tokenResponse));
+        String redirectUri = UriComponentsBuilder
+                .fromUriString(frontendBaseUri + callbackPath)
+                .queryParam("accessToken", accessToken)
+                .queryParam("refreshToken", refreshToken)
+                .build().toUriString();
+
+        log.info("로그인 성공 후 리디렉트 URI: {}", redirectUri);
+
+        response.sendRedirect(redirectUri);
     }
 
 }


### PR DESCRIPTION
## 🔍 개요  
기존 OAuth2 로그인 성공 후 서버에서 JSON 형태로 AccessToken과 RefreshToken을 응답하던 방식을  
**프론트와 연동이 가능한 리디렉트 방식**으로 변경하였습니다.

---

## 🔧 변경 사항  

- `OAuth2SuccessHandler` 내부 로직 변경  
  - `response.getWriter().write(...)` → `response.sendRedirect(...)`  
- 로그인 성공 시 provider(Google, Kakao)에 따라 프론트 콜백 주소로 리디렉트  
  - `http://localhost:3000/api/auth/callback/google`  
  - `http://localhost:3000/api/auth/callback/kakao`  
- 리디렉트 URL에 `accessToken`, `refreshToken`을 쿼리 파라미터로 포함하여 전달

---

## 📌 변경 이유  

- 기존 JSON 응답 방식은 브라우저에서 소셜 로그인 요청 시 응답이 그대로 표시되어 사용자 경험이 떨어졌음  
- 프론트 측에서 `/api/auth/callback/{provider}` 경로에서 토큰을 수신하고 저장하는 방식으로 요구되어 구조를 변경함  
- 토큰 전달 후, 자동으로 메인 페이지로 이동하거나 후처리를 진행할 수 있도록 개선됨

---

## 🧪 테스트 방법  

1. `/oauth2/authorization/google` 또는 `/oauth2/authorization/kakao`로 로그인 시도  
2. 로그인 성공 후 프론트 콜백 주소(`/api/auth/callback/{provider}`)로 리디렉트되는지 확인  
3. URL 파라미터로 토큰이 잘 전달되는지 확인  
4. 프론트에서 로컬 스토리지에 저장 및 이후 인증 요청 정상 동작 확인

---

## 📝 기타  

- **Google / Kakao 개발자 콘솔**에 콜백 URI (`http://localhost:3000/api/auth/callback/*`) 등록 완료되어야 함  
- 배포 시 `localhost` → 실서버 주소로 리디렉트 URI 수정 필요  
- 추후 보안 강화를 위해:
  - `postMessage` 기반 전달 방식
  - `HttpOnly` Secure 쿠키 방식  
  등의 방식으로 변경 가능
