### PR TITLE
fix: PostgreSQL에서 TEXT 데이터 바이너리 저장 문제 해결 및 타임존 변경

### DIFF
--- a/be/src/main/java/com/interviewmate/be/prompt/application/PromptService.java
+++ b/be/src/main/java/com/interviewmate/be/prompt/application/PromptService.java
@@ -9,6 +9,7 @@ import com.interviewmate.be.prompt.domain.Prompt;
 import com.interviewmate.be.prompt.dto.PromptListResponse;
 import com.interviewmate.be.question.domain.Question;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +22,7 @@ import java.util.List;
  * date           : 2025-03-24
  * description    : 프롬프트 저장 및 관련 로직을 담당하는 서비스
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PromptService {
@@ -39,6 +41,8 @@ public class PromptService {
      */
     @Transactional
     public Prompt savePrompt(User user, String promptContent, String title) {
+        log.info("저장될 프롬프트: {}", promptContent);
+
         Prompt prompt = Prompt.builder()
                 .user(user)
                 .prompt(promptContent)

--- a/be/src/main/java/com/interviewmate/be/prompt/domain/Prompt.java
+++ b/be/src/main/java/com/interviewmate/be/prompt/domain/Prompt.java
@@ -36,8 +36,7 @@ public class Prompt {
     @Column(nullable = false)
     private String title;
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String prompt;
 
     @Column(name = "is_active")

--- a/be/src/main/java/com/interviewmate/be/question/domain/Question.java
+++ b/be/src/main/java/com/interviewmate/be/question/domain/Question.java
@@ -36,8 +36,7 @@ public class Question {
     @Column(nullable = false)
     private int number; // 프롬프트 내 질문 번호 (1~5, 혹은 6...)
 
-    @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String question; // 질문
 
     @Column(name = "is_active")

--- a/be/src/main/resources/config/application-database.yml
+++ b/be/src/main/resources/config/application-database.yml
@@ -1,4 +1,7 @@
 spring:
+  jackson:
+    time-zone: Asia/Seoul
+
   datasource:
     driver-class-name: org.postgresql.Driver
     url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
@@ -8,10 +11,12 @@ spring:
   jpa:
     show-sql: true # 콘솔에 SQL 쿼리를 출력할지 여부를 결정
     hibernate:
-      ddl-auto: none
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true # SQL 쿼리를 보기 좋게 포맷팅
+        jdbc:
+          time_zone: Asia/Seoul
 
   data:
     redis:


### PR DESCRIPTION
- Prompt와 Question 엔티티에서 @Lob 어노테이션 제거
- columnDefinition="TEXT" 명시적 지정으로 텍스트 저장 방식 강제

오류 원인: JPA의 @Lob 어노테이션이 PostgreSQL에서 bytea(바이너리) 타입으로 자동 매핑되어 문자열이 숫자로 저장되는 문제 발생